### PR TITLE
Add support for entire Newsletter API area

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
 npm-debug.log
+test.js
+.idea

--- a/lib/newsletter/email.js
+++ b/lib/newsletter/email.js
@@ -1,0 +1,138 @@
+"use strict";
+
+var request = require('request');
+
+/**
+ * Class to handle adding emails to an existing list
+ *
+ */
+var Email = function(sendgrid, params) {
+
+    params = params || {};
+
+    this.sendgrid = sendgrid;
+    this.params = params;
+};
+
+/**
+ * Adds an email address to an existing list
+ *
+ * @param  {string}         listname        The name of the list to add to
+ * @param  {Object}         data            The data object to add to the list
+ * @param  {Function}       callback        A function to call when the processing is done.
+ */
+Email.prototype.add = function(listname, data, callback) {
+
+    var req = {
+        url   : 'https://sendgrid.com/api/newsletter/lists/email/add.json',
+        form  : this.sendgrid.merge(
+            this.sendgrid.addAuthKeys(),
+            {
+                list: listname,
+                data: JSON.stringify(data)
+            }),
+        method: "post"
+    };
+
+    request(req, function(error, response, body) {
+        if (error) {
+            return callback(error);
+        }
+        else {
+            return callback(error, {
+                response: response,
+                body    : body
+            });
+        }
+    });
+};
+
+/**
+ * Remove an email from a list
+ *
+ * @param  {string}         listname        The name of the list to remove from
+ * @param  {string}         email           The email address to remove
+ * @param  {Function}       callback        A function to call when the processing is done.
+ */
+Email.prototype.del = function(listname, email, callback) {
+
+    if (!listname || !email) {
+        throw "Missing required parameters";
+    }
+
+    var req = {
+        url   : 'https://sendgrid.com/api/newsletter/lists/email/delete.json',
+        qs    : this.sendgrid.merge(
+            this.sendgrid.addAuthKeys(),
+            {
+                list: listname,
+                email: email
+            }),
+        method: "get"
+    };
+
+    request(req, function(error, response, body) {
+        if (error) {
+            return callback(error);
+        }
+        else {
+            return callback(error, {
+                response: response,
+                body    : body
+            });
+        }
+    });
+};
+
+/**
+ * Gets the emails for a given list, and optionally matching the supplied email
+ *
+ * @param  {string}         listname        The name of the list to search
+ * @param  {string}         email           Optional. An email address to search
+ *                                          in the specified list
+ * @param  {Function}       callback        A function to call when the processing is done.
+ */
+Email.prototype.get = function(listname, email, callback) {
+
+    if (!listname) {
+        throw "Missing required parameters";
+    }
+
+    if (typeof(email) === 'function') {
+        callback = email;
+        email = null;
+    }
+
+    var data = {
+        list: listname
+    };
+
+    if (email) {
+        data.email = email;
+    }
+
+    var req = {
+        url   : 'https://sendgrid.com/api/newsletter/lists/email/get.json',
+        qs    : this.sendgrid.merge(
+            this.sendgrid.addAuthKeys(),
+            data),
+        method: "get"
+    };
+
+    request(req, function(error, response, body) {
+        if (error) {
+            return callback(error);
+        }
+        else {
+            return callback(error, {
+                response: response,
+                body    : body
+            });
+        }
+    });
+};
+
+/**
+ // export the object as the only object in this module
+ */
+module.exports = Email;

--- a/lib/newsletter/identity.js
+++ b/lib/newsletter/identity.js
@@ -1,0 +1,197 @@
+"use strict";
+
+var request = require('request');
+
+/**
+ * Class to handle managing identities
+ *
+ */
+var Identity = function(sendgrid, params) {
+
+    params = params || {};
+
+    this.sendgrid = sendgrid;
+    this.params = params;
+};
+
+/**
+ * Adds an new identity to your sendgrid account
+ *
+ * @param  {Object}         data            The data object representing the new identity
+ * @param  {Function}       callback        A function to call when the processing is done.
+ */
+Identity.prototype.add = function(data, callback) {
+
+    // Validate required parameters
+    if (!data.identity || !data.name ||
+        !data.email || !data.address ||
+        !data.city || !data.state ||
+        !data.zip || !data.country) {
+        throw "Missing required paramters";
+    }
+
+    var req = {
+        url   : 'https://sendgrid.com/api/newsletter/identity/add.json',
+        form  : this.sendgrid.merge(
+            this.sendgrid.addAuthKeys(),
+            data),
+        method: "post"
+    };
+
+    request(req, function(error, response, body) {
+        if (error) {
+            return callback(error);
+        }
+        else {
+            return callback(error, {
+                response: response,
+                body    : body
+            });
+        }
+    });
+};
+
+/**
+ * Remove an identity
+ *
+ * @param  {string}         identity        The name of the identity to remove
+ * @param  {Function}       callback        A function to call when the processing is done.
+ */
+Identity.prototype.del = function(identity, callback) {
+
+    if (!identity) {
+        throw "Missing required parameters";
+    }
+
+    var req = {
+        url   : 'https://sendgrid.com/api/newsletter/identity/delete.json',
+        qs    : this.sendgrid.merge(
+            this.sendgrid.addAuthKeys(),
+            {
+                identity: identity
+            }),
+        method: "get"
+    };
+
+    request(req, function(error, response, body) {
+        if (error) {
+            return callback(error);
+        }
+        else {
+            return callback(error, {
+                response: response,
+                body    : body
+            });
+        }
+    });
+};
+
+/**
+ * Get an identity
+ *
+ * @param  {string}         identity        The name of the identity to get
+ * @param  {Function}       callback        A function to call when the processing is done.
+ */
+Identity.prototype.get = function(identity, callback) {
+
+    if (!identity) {
+        throw "Missing required parameters";
+    }
+
+    var req = {
+        url   : 'https://sendgrid.com/api/newsletter/identity/get.json',
+        qs    : this.sendgrid.merge(
+            this.sendgrid.addAuthKeys(),
+            {
+                identity: identity
+            }),
+        method: "get"
+    };
+
+    request(req, function(error, response, body) {
+        if (error) {
+            return callback(error);
+        }
+        else {
+            return callback(error, {
+                response: response,
+                body    : body
+            });
+        }
+    });
+};
+
+/**
+ * Gets the identities for the account, and optionally matching the supplied name
+ *
+ * @param  {string}         identity        Optional. An identity name to search for.
+ * @param  {Function}       callback        A function to call when the processing is done.
+ */
+Identity.prototype.list = function(identity, callback) {
+
+    if (typeof(identity) === 'function') {
+        callback = identity;
+        identity = null;
+    }
+
+    var req = {
+        url   : 'https://sendgrid.com/api/newsletter/identity/list.json',
+        qs    : this.sendgrid.merge(
+            this.sendgrid.addAuthKeys(),
+            identity ? {
+                identity: identity
+            } : {}),
+        method: "get"
+    };
+
+    request(req, function(error, response, body) {
+        if (error) {
+            return callback(error);
+        }
+        else {
+            return callback(error, {
+                response: response,
+                body    : body
+            });
+        }
+    });
+};
+
+/**
+ * Update an  identity in your sendgrid account
+ *
+ * @param  {Object}         data            The data object representing the identity to update
+ * @param  {Function}       callback        A function to call when the processing is done.
+ */
+Identity.prototype.edit = function(data, callback) {
+
+    // Validate required parameters
+    if (!data.identity) {
+        throw "Missing required paramters";
+    }
+
+    var req = {
+        url   : 'https://sendgrid.com/api/newsletter/identity/edit.json',
+        form  : this.sendgrid.merge(
+            this.sendgrid.addAuthKeys(),
+            data),
+        method: "post"
+    };
+
+    request(req, function(error, response, body) {
+        if (error) {
+            return callback(error);
+        }
+        else {
+            return callback(error, {
+                response: response,
+                body    : body
+            });
+        }
+    });
+};
+
+/**
+ // export the object as the only object in this module
+ */
+module.exports = Identity;

--- a/lib/newsletter/lists.js
+++ b/lib/newsletter/lists.js
@@ -1,0 +1,159 @@
+"use strict";
+
+var request = require('request');
+
+var Email = require('./email');
+
+/**
+ * Class to handle managing Distribution lists
+ *
+ */
+var Lists = function(sendgrid, params) {
+
+    params = params || {};
+
+    this.sendgrid = sendgrid;
+    this.params = params;
+
+    this.Email = new Email(sendgrid, {});
+};
+
+/**
+ * Adds an new distribution list
+ *
+ * @param  {string}         listname        The name of the new list
+ * @param  {Function}       callback        A function to call when the processing is done.
+ */
+Lists.prototype.add = function(listname, callback) {
+
+    var req = {
+        url: 'https://sendgrid.com/api/newsletter/lists/add.json',
+        qs: this.sendgrid.merge(
+            this.sendgrid.addAuthKeys(),
+            {
+                list: listname
+            }),
+        method: "get"
+    };
+
+    request(req, function(error, response, body) {
+        if (error) {
+            return callback(error);
+        }
+        else {
+            return callback(error, {
+                response: response,
+                body: body
+            });
+        }
+    });
+};
+
+/**
+ * Deletes a distribution list
+ *
+ * @param  {string}         listname        The name of the list to delete
+ * @param  {Function}       callback        A function to call when the processing is done.
+ */
+Lists.prototype.del = function(listname, callback) {
+
+    var req = {
+        url   : 'https://sendgrid.com/api/newsletter/lists/delete.json',
+        qs    : this.sendgrid.merge(
+            this.sendgrid.addAuthKeys(),
+            {
+                list: listname
+            }),
+        method: "get"
+    };
+
+    request(req, function(error, response, body) {
+        if (error) {
+            return callback(error);
+        }
+        else {
+            return callback(error, {
+                response: response,
+                body    : body
+            });
+        }
+    });
+};
+
+/**
+ * Get all of the distribution lists on your account.
+ * Optionally search for a specific list name.
+ *
+ * @param  {string}         listname        Optional. The name of the list to search for.
+ * @param  {Function}       callback        A function to call when the processing is done.
+ */
+Lists.prototype.get = function(listname, callback) {
+
+    if (typeof(listname) === 'function') {
+        callback = listname;
+        listname = null;
+    }
+
+    var req = {
+        url   : 'https://sendgrid.com/api/newsletter/lists/get.json',
+        qs    : this.sendgrid.merge(
+            this.sendgrid.addAuthKeys(),
+            listname ? {
+                list: listname
+            } : {}),
+        method: "get"
+    };
+
+    request(req, function(error, response, body) {
+        if (error) {
+            return callback(error);
+        }
+        else {
+            return callback(error, {
+                response: response,
+                body    : body
+            });
+        }
+    });
+};
+
+/**
+ * Edit a distribution list
+ *
+ * @param  {string}         listname        The name of the list
+ * @param  {string}         newListname     The name to change the list to
+ * @param  {Function}       callback        A function to call when the processing is done.
+ */
+Lists.prototype.edit = function(listname, newListname, callback) {
+
+    if ((typeof(listname) !== 'string') || (typeof(newListname) !== 'string')) {
+        throw 'Missing required arguments';
+    }
+
+    var req = {
+        url   : 'https://sendgrid.com/api/newsletter/lists/edit.json',
+        qs    : this.sendgrid.merge(
+            this.sendgrid.addAuthKeys(), {
+                list: listname,
+                newlist: newListname
+            }),
+        method: "get"
+    };
+
+    request(req, function(error, response, body) {
+        if (error) {
+            return callback(error);
+        }
+        else {
+            return callback(error, {
+                response: response,
+                body    : body
+            });
+        }
+    });
+};
+
+/**
+ // export the object as the only object in this module
+ */
+module.exports = Lists;

--- a/lib/newsletter/newsletter.js
+++ b/lib/newsletter/newsletter.js
@@ -1,0 +1,215 @@
+"use strict";
+
+var request = require('request'),
+    Identity = require('./identity.js'),
+    Lists = require('./lists.js'),
+    Recipients = require('./recipients'),
+    Schedule = require('./schedule');
+
+/**
+ * Class to handle Newsletter and all of the surrounding APIs
+ *
+ * newsletter.Identity to manage Identities
+ * newsletter.Lists to manage DLs
+ * newsletter.Lists.Email to manage list recipients
+ * newsletter.Recipients to map lists to newsletters
+ * newsletter.Schedule to schedule newsletters for delivery
+ *
+ */
+function Newsletter(sendgrid, params) {
+
+    params = params || {};
+
+    this.sendgrid = sendgrid;
+    this.params = params;
+
+    this.Identity = new Identity(sendgrid, {});
+    this.Lists = new Lists(sendgrid, {});
+    this.Recipients = new Recipients(sendgrid, {});
+    this.Schedule = new Schedule(sendgrid, {});
+}
+
+/**
+ * Create a new newsletter
+ *
+ * @param  {Object}         data        The newsletter to add.
+ * @param  {Function}       callback    A function to call when the processing is done.
+ */
+// TODO Better document schema for data object
+Newsletter.prototype.add = function(data, callback) {
+
+    if (!data.identity || !data.name ||
+        !data.subject || !data.text ||
+        !data.html) {
+        throw "Missing required parameters";
+    }
+
+    var req = {
+        url   : 'https://sendgrid.com/api/newsletter/add.json',
+        form    : this.sendgrid.merge(
+            this.sendgrid.addAuthKeys(),
+            {
+                list: listname
+            }),
+        method: "post"
+    };
+
+    request(req, function(error, response, body) {
+        if (error) {
+            return callback(error);
+        }
+        else {
+            return callback(error, {
+                response: response,
+                body    : body
+            });
+        }
+    });
+};
+
+/**
+ * Edit a new newsletter
+ *
+ * @param  {Object}         data        The newsletter to update
+ * @param  {Function}       callback    A function to call when the processing is done.
+ */
+// TODO Better document schema for data object
+Newsletter.prototype.edit = function(data, callback) {
+
+    if (!data.identity || !data.name ||
+        !data.subject || !data.text ||
+        !data.html || data.newname) {
+        throw "Missing required parameters";
+    }
+
+    var req = {
+        url   : 'https://sendgrid.com/api/newsletter/edit.json',
+        form  : this.sendgrid.merge(
+            this.sendgrid.addAuthKeys(),
+            data),
+        method: "post"
+    };
+
+    request(req, function(error, response, body) {
+        if (error) {
+            return callback(error);
+        }
+        else {
+            return callback(error, {
+                response: response,
+                body    : body
+            });
+        }
+    });
+};
+
+/**
+ * Get a newsletter by name
+ *
+ * @param  {string}         name        The newsletter to get
+ * @param  {Function}       callback    A function to call when the processing is done.
+ */
+Newsletter.prototype.get = function(name, callback) {
+
+    if (!name) {
+        throw "Missing required parameters";
+    }
+
+    var req = {
+        url   : 'https://sendgrid.com/api/newsletter/get.json',
+        qs    : this.sendgrid.merge(
+            this.sendgrid.addAuthKeys(),
+            {
+                name: name
+            }),
+        method: "get"
+    };
+
+    request(req, function(error, response, body) {
+        if (error) {
+            return callback(error);
+        }
+        else {
+            return callback(error, {
+                response: response,
+                body    : body
+            });
+        }
+    });
+};
+
+/**
+ * Lists all of your newsletters. Optionally search for a specific newsletter
+ *
+ * @param  {string}         name        Optional. The newsletter to search for
+ * @param  {Function}       callback    A function to call when the processing is done.
+ */
+Newsletter.prototype.list = function(name, callback) {
+
+    if (typeof(name) === 'function') {
+        callback = name;
+        name = null;
+    }
+
+    var req = {
+        url   : 'https://sendgrid.com/api/newsletter/list.json',
+        qs    : this.sendgrid.merge(
+            this.sendgrid.addAuthKeys(),
+            name ? {
+                name: name
+            } : {}),
+        method: "get"
+    };
+
+    request(req, function(error, response, body) {
+        if (error) {
+            return callback(error);
+        }
+        else {
+            return callback(error, {
+                response: response,
+                body    : body
+            });
+        }
+    });
+};
+
+/**
+ * Delete a new newsletter
+ *
+ * @param  {string}         name        The newsletter to delete
+ * @param  {Function}       callback    A function to call when the processing is done.
+ */
+Newsletter.prototype.del = function(name, callback) {
+
+    if (!name) {
+        throw "Missing required parameters";
+    }
+
+    var req = {
+        url   : 'https://sendgrid.com/api/newsletter/delete.json',
+        qs    : this.sendgrid.merge(
+            this.sendgrid.addAuthKeys(),
+            {
+                name: name
+            }),
+        method: "get"
+    };
+
+    request(req, function(error, response, body) {
+        if (error) {
+            return callback(error);
+        }
+        else {
+            return callback(error, {
+                response: response,
+                body    : body
+            });
+        }
+    });
+};
+
+/**
+// export the object as the only object in this module
+*/
+module.exports = Newsletter;

--- a/lib/newsletter/recipients.js
+++ b/lib/newsletter/recipients.js
@@ -1,0 +1,129 @@
+"use strict";
+
+var request = require('request');
+
+/**
+ * Class to handle mapping lists to a newsletter
+ *
+ */
+var Recipients = function(sendgrid, params) {
+
+    params = params || {};
+
+    this.sendgrid = sendgrid;
+    this.params = params;
+};
+
+/**
+ * Adds a list to a newsletter as the recipients
+ *
+ * @param  {string}         newsletter      The name of the newsletter
+ * @param  {string}         list            The name of the list to provide as the recipient
+ * @param  {Function}       callback        A function to call when the processing is done.
+ */
+Recipients.prototype.add = function(newsletter, list, callback) {
+
+    if (!newsletter || !list) {
+        throw "Missing required parameters";
+    }
+
+    var req = {
+        url   : 'https://sendgrid.com/api/newsletter/recipients/add.json',
+        qs    : this.sendgrid.merge(
+            this.sendgrid.addAuthKeys(),
+            {
+                list: list,
+                name: newsletter
+            }),
+        method: "get"
+    };
+
+    request(req, function(error, response, body) {
+        if (error) {
+            return callback(error);
+        }
+        else {
+            return callback(error, {
+                response: response,
+                body    : body
+            });
+        }
+    });
+};
+
+/**
+ * Removes a list from a newsletters recipients
+ *
+ * @param  {string}         newsletter      The name of the newsletter
+ * @param  {string}         list            The name of the list to remove
+ * @param  {Function}       callback        A function to call when the processing is done.
+ */
+Recipients.prototype.del = function(newsletter, list, callback) {
+
+    if (!newsletter || !list) {
+        throw "Missing required parameters";
+    }
+
+    var req = {
+        url   : 'https://sendgrid.com/api/newsletter/recipients/delete.json',
+        qs    : this.sendgrid.merge(
+            this.sendgrid.addAuthKeys(),
+            {
+                list: list,
+                name: newsletter
+            }),
+        method: "get"
+    };
+
+    request(req, function(error, response, body) {
+        if (error) {
+            return callback(error);
+        }
+        else {
+            return callback(error, {
+                response: response,
+                body    : body
+            });
+        }
+    });
+};
+
+/**
+ * Gets the list of recipients for a newsletter
+ *
+ * @param  {string}         newsletter      The name of the newsletter
+ * @param  {Function}       callback        A function to call when the processing is done.
+ */
+Recipients.prototype.get = function(newsletter, callback) {
+
+    if (!newsletter) {
+        throw "Missing required parameters";
+    }
+
+    var req = {
+        url   : 'https://sendgrid.com/api/newsletter/recipients/get.json',
+        qs    : this.sendgrid.merge(
+            this.sendgrid.addAuthKeys(),
+            {
+                name: newsletter
+            }),
+        method: "get"
+    };
+
+    request(req, function(error, response, body) {
+        if (error) {
+            return callback(error);
+        }
+        else {
+            return callback(error, {
+                response: response,
+                body    : body
+            });
+        }
+    });
+};
+
+/**
+ // export the object as the only object in this module
+ */
+module.exports = Recipients;

--- a/lib/newsletter/schedule.js
+++ b/lib/newsletter/schedule.js
@@ -1,0 +1,140 @@
+"use strict";
+
+var request = require('request');
+
+/**
+ * Class to handle scheduling a newsletter for delivery
+ *
+ */
+var Schedule = function(sendgrid, params) {
+
+    params = params || {};
+
+    this.sendgrid = sendgrid;
+    this.params = params;
+};
+
+/**
+ * Schedules a newsletter for delivery. If delay is not specified the
+ * newsletter is scheduled for immediate delivery
+ *
+ * @param  {string}         newsletter      The name of the newsletter to schedule
+ * @param  {integer}        delay           Delay in minutes to schedule delivery
+ * @param  {Function}       callback        A function to call when the processing is done.
+ */
+// TODO Add explicit support for At in lieu of delay
+Schedule.prototype.add = function(newsletter, delay, callback) {
+
+    if (!newsletter) {
+        throw "Missing required parameters";
+    }
+
+    // Shift args if delay is not supplied
+    if (typeof(delay) === 'function') {
+        callback = delay;
+        delay = null;
+    }
+
+    var data = {
+        name: newsletter
+    };
+
+    if (delay) {
+        data.delay = delay;
+    }
+
+    var req = {
+        url   : 'https://sendgrid.com/api/newsletter/schedule/add.json',
+        qs    : this.sendgrid.merge(
+            this.sendgrid.addAuthKeys(),
+            data),
+        method: "get"
+    };
+
+    request(req, function(error, response, body) {
+        if (error) {
+            return callback(error);
+        }
+        else {
+            return callback(error, {
+                response: response,
+                body    : body
+            });
+        }
+    });
+};
+
+/**
+ * Deletes a scheduled newsletter
+ *
+ * @param  {string}         newsletter      The name of the newsletter to unschedule
+ * @param  {Function}       callback        A function to call when the processing is done.
+ */
+Schedule.prototype.del = function(newsletter, callback) {
+
+    if (!newsletter) {
+        throw "Missing required parameters";
+    }
+
+    var req = {
+        url   : 'https://sendgrid.com/api/newsletter/schedule/delete.json',
+        qs    : this.sendgrid.merge(
+            this.sendgrid.addAuthKeys(),
+            {
+                name: newsletter
+            }),
+        method: "get"
+    };
+
+    request(req, function(error, response, body) {
+        if (error) {
+            return callback(error);
+        }
+        else {
+            return callback(error, {
+                response: response,
+                body    : body
+            });
+        }
+    });
+};
+
+/**
+ * Get the schedule for a scheduled newsletter
+ *
+ * @param  {string}         newsletter      The name of the newsletter to get the schedule for
+ * @param  {Function}       callback        A function to call when the processing is done.
+ */
+Schedule.prototype.get = function(newsletter, callback) {
+
+    if (!newsletter) {
+        throw "Missing required parameters";
+    }
+
+    var req = {
+        url   : 'https://sendgrid.com/api/newsletter/schedule/get.json',
+        qs    : this.sendgrid.merge(
+            this.sendgrid.addAuthKeys(),
+            {
+                name: newsletter
+            }),
+        method: "get"
+    };
+
+    request(req, function(error, response, body) {
+        if (error) {
+            return callback(error);
+        }
+        else {
+            return callback(error, {
+                response: response,
+                body    : body
+            });
+        }
+    });
+};
+
+/**
+ // export the object as the only object in this module
+ */
+module.exports = Schedule;

--- a/lib/sendgrid.js
+++ b/lib/sendgrid.js
@@ -8,6 +8,7 @@ var path = require('path');
 var mime = require('mime');
 
 var Email = require('./email');
+var Newsletter = require('./newsletter/newsletter');
 
 /*
  * Class for handling communications with SendGrid.
@@ -18,6 +19,8 @@ var Email = require('./email');
 function SendGrid(api_user, api_key) {
   this.api_user = api_user;
   this.api_key = api_key;
+
+  this.Newsletter = new Newsletter(this, {});
 }
 
 /*
@@ -193,6 +196,48 @@ SendGrid.prototype.getMultipartData = function(email, boundary) {
   });
 
   return data;
+};
+
+/*
+ * Function for internal use.
+ *
+ * Used for adding the user and key to calls
+ *
+ * @return  {Object}     An object with the api_user and api_key defined
+ *
+ */
+SendGrid.prototype.addAuthKeys = function() {
+    return {
+        api_user: this.api_user,
+        api_key : this.api_key
+    };
+};
+
+/*
+ * Function for internal use.
+ *
+ * Used for merging objects together
+ *
+ * @param   {Object}  obj       The source object.
+ * @param   {String}  toMerge   The object to merge into source.
+ * @param   {boolean} override  Override values on obj if present on toMerge
+ * @return  {Object}            The merged object
+ *
+ */
+SendGrid.prototype.merge = function(obj, toMerge, override) {
+    for (var i in toMerge) {
+        if (!toMerge.hasOwnProperty(i)) {
+            continue;
+        }
+
+        if (!override && obj.hasOwnProperty(i)) {
+            continue;
+        }
+
+        obj[i] = toMerge[i];
+    }
+
+    return obj;
 };
 
 /*

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "underscore": ">=1.2.4",
     "nodemailer": "*",
     "mime": "*",
-    "step": ">= 0.0.5"
+    "step": ">= 0.0.5",
+    "request": "*"
   },
   "devDependencies": {
     "mocha": ">= 0.9.0",


### PR DESCRIPTION
## Caveat

**I don't expect this PR to be accepted as is, but I wanted to start the dialog about how and what form this might take.**
## Overview

I've added the support for all of the newsletter APIs with very crude error handling, input validation, minimal documentation, and no unit tests.

The APIs that are supported are:
- Newsletter
- Newsletter - Lists
- Newsletter - Lists - Email
- Newsletter - Schedule
- Newsletter - Recipients
- Newsletter - Identity

All of these are implemented using the [Request module](https://github.com/mikeal/request) which nicely abstracts away the particulars of using HTTP/HTTPS calls.

I've tentatively added these as sub objects of the master Sendgrid object, but I'm not convinced that is the best way to factor these, but this is good enough to get the ball rolling.

Here's a couple of examples:

``` javascript

var Sendgrid = require('sendgrid'),
    sendgrid = new Sendgrid('myuser', 'mypassword');

sendgrid.Newsletter.Lists.Email.add('mylist', {
        email: 'ken@mydomain.com',
        name: 'ken',
        displayName: 'Ken Perkins'
    }, function(err, result) {
        if (err) {
            console.dir(err);
            process.exit(1);
        }

        console.dir(result.body);
});

sendgrid.Newsletter.Identity.add({
        identity: 'testIdentity',
        name: 'My Identity',
        email: 'support@mydomain.com',
        address: '12345 Anystreet S',
        city: 'Seattle',
        state: 'WA',
        zip: '98104',
        country: 'usa'
    }, function(err, result) {

        if (err) {
            console.dir(err);
        }

        console.dir(result.body);
});
```
