### PR TITLE
Fromname support for webApi

### DIFF
--- a/lib/email.js
+++ b/lib/email.js
@@ -13,6 +13,7 @@ var _ = require('underscore');
  * @param  {Object}          params
  * @param  {string|array}    params.to       The to address(es) of the email
  * @param  {string}          params.from     The from address of the email
+ * @param  {string}          params.fromname The display name of the email sender
  * @param  {SmtpapiHeaders}  params.smtpapi  The SendGrid x-smtpapi headers object
  * @param  {string}          params.subject  The subject of the email
  * @param  {string}          params.text     The text/plain content of an email
@@ -27,6 +28,7 @@ function Email(params) {
 
   this.to      = params.to      || [];
   this.from    = params.from    || '';
+  this.fromname= params.fromname|| '';
   this.smtpapi = params.smtpapi || new SmtpapiHeaders();
   this.subject = params.subject || '';
   this.text    = params.text    || '';
@@ -214,6 +216,7 @@ Email.prototype.toWebFormat = function() {
   var data = {
     to: this.to,
     from: this.from,
+    fromname: this.fromname,
     'x-smtpapi': this.smtpapi.toJson(),
     subject: this.subject,
     text: this.text,


### PR DESCRIPTION
Hi there --

I added support for the fromname field (defaulting to '') to the email params object.  If you guys could pull this in, that'd be great.

Thanks,

-sb
