### PR TITLE
Add support for formatted addresses.

### DIFF
--- a/lib/email.js
+++ b/lib/email.js
@@ -7,12 +7,15 @@ var SmtpapiHeaders = require('./smtpapi_headers');
 var FileHandler = require('./file_handler');
 var _ = require('underscore');
 
+//expression to match a formatted address
+var fmt = /^\s*\"?\s*([^\"]*)\s*\"?\s*\<([^\>]+)\>$/;
+
 /**
  * Class to handle storing the properties relative to an email.
  *
  * @param  {Object}          params
  * @param  {string|array}    params.to       The to address(es) of the email
- * @param  {string|array}    params.fromname The display name of the email recipients
+ * @param  {string|array}    params.toname   The display name of the email recipients
  * @param  {string}          params.from     The from address of the email
  * @param  {string}          params.fromname The display name of the email sender
  * @param  {SmtpapiHeaders}  params.smtpapi  The SendGrid x-smtpapi headers object
@@ -37,6 +40,8 @@ function Email(params) {
   this.replyto = params.replyto || '';
   this.date    = params.date    || new Date();
   this.headers = params.headers || {};
+
+  var encAddr = /\s*\<([^\>]+)\>$/;
 
   if(params.toname != null) {
     this.toname = params.toname;
@@ -293,6 +298,79 @@ Email.prototype.updateMissingTo = function(data) {
 Email.prototype.hasFiles = function() {
   return _(this.files).size() > 0;
 };
+
+/**
+ * This method will normalize any formatted addresses ('"name" <address>')
+ */
+Email.prototype.handleFormattedAddresses = function(){
+  handleFromFmt(this);
+  handleToFmt(this);
+  handleBccFmt(this);
+}
+
+//converts a formatted from address into separate name/address parts
+function handleFromFmt(email) {
+  if (email.fromname) return; //nothing to do - already has name set
+  if (!fmt.test(email.from)) return; //nothing to do - not formatted
+  var anp = getAddressNamePair(email.from);
+console.log("FROM");
+console.dir(anp);
+  email.from = anp[0];
+  if (anp.length > 1) email.fromname = anp[1];
+}
+
+//converts any formatted bcc addresses into just the address part
+function handleBccFmt(email) {
+  if (!email.bcc) return;
+  var bcc = (email.bcc instanceof Array) ? email.bcc : [email.bcc];
+  email.bcc = getAddressNamePairs(bcc).map(function(anp){ return anp[0]; });
+}
+
+//if there are formatted addresses in the to field, will convert to 
+//separate arrays of to/name fields
+function handleToFmt(email) {
+  if (email.toname) return; //nothing to do - already has name set
+
+  //make value(s) an array
+  var to = (email.to instanceof Array) ? email.to : [email.to];
+
+  //do any values have a formatted address?
+  var hasFmt = to.some(function(addr){
+    return fmt.test(addr);
+  });
+
+  //no formatted addresses, leave the values alone
+  if (!hasFmt) return; //nothing to do - none formatted
+
+  //convert array to name/value pairs
+  to = getAddressNamePairs(to);
+
+  //map the to field(s)
+  email.to = to.map(function(anp){
+    return anp[0];
+  });
+
+  //map the toname field(s)
+  email.toname = to.map(function(anp){
+    return anp[1] || anp[0];
+  });
+}
+
+//converts an array of addresses to an array of address/name pairs
+function getAddressNamePairs(addrs) {
+  if (addrs instanceof String) addrs = [addrs];
+  if (!(addrs instanceof Array)) return [];
+  return addrs.map(getAddressNamePair);
+}
+
+//converts a single address to an address/name pair
+function getAddressNamePair(addr) {
+  var m = (addr || '').match(fmt);
+  if (!m) return [addr || ''];
+  if (m[1]) return [m[2],m[1]];
+  return [m[2]];
+}
+
 
 // export the object as the only object in this module
 module.exports = Email;

--- a/lib/sendgrid.js
+++ b/lib/sendgrid.js
@@ -47,6 +47,8 @@ SendGrid.prototype.send = function(email, callback) {
       method: 'POST'
     };
 
+    email.handleFormattedAddresses();
+
     if (email.hasFiles()) {
       post_data = self.getMultipartData(email, boundary);
       var length = 0;


### PR DESCRIPTION
Adding support for formatted '<code>"name" &lt;address&gt;</code>' blocks for from/to/bcc which will convert formatted addresses into the expected format.

My existing mail system (and would suspect others as well) currently uses a '<code>"name" &lt;address&gt;</code>' format for handling email addresses with given display names... it's a common format for email clients as well.  I added an additional method call to sendgrid.js (within .send()) and related functionality within Email.js

It would probably be best to add this support upstream in the service itself, for now, I've added it into the sendgrid-nodejs project.

_(note: fixed line endings from prior commit)_
