### PR TITLE
Handle HTTP error to avoid throwing exceptions

### DIFF
--- a/lib/sendgrid.js
+++ b/lib/sendgrid.js
@@ -75,6 +75,8 @@ SendGrid.prototype.send = function(email, callback) {
         var json = JSON.parse(content);
         cb(json.message == 'success', json.errors);
       });
+    }).on('error', function(error){
+      return callback(false, error);
     });
 
     // If the email has files, it will be a multipart request.


### PR DESCRIPTION
Sendgrid crashes application on HTTP error
