### PR TITLE
use error object for 'err' callback param

### DIFF
--- a/lib/sendgrid.js
+++ b/lib/sendgrid.js
@@ -67,11 +67,11 @@ module.exports = function(api_user, api_key) {
       if (json.message !== 'success') {
         var error = 'sendgrid error';
         if (json.errors) { error = json.errors.shift(); }
-        return callback(error, null);
+        return callback(new Error(error), null);
       }
 
       return callback(null, json);
-    }); 
+    });
 
     var form          = email.toWebFormat();
     form['api_user']  = api_user;

--- a/test/lib/sendgrid.test.js
+++ b/test/lib/sendgrid.test.js
@@ -48,7 +48,8 @@ describe('SendGrid', function () {
       mock = webApi.reply(500, { message: "error", errors: ["some error"] });
 
       sendgrid.send({}, function(err, json) {
-        expect(err).to.equal("some error");
+        expect(err.stack);
+        expect(err.message).to.equal("some error");
         done();
       });
     });


### PR DESCRIPTION
Error object contain stacktraces and additional information that helps
debug potential issues. They are expected as the first argument versus
just a string.
