### PR TITLE
Add optional nodeMailerOptions argument to sendgrid.smtp

### DIFF
--- a/lib/sendgrid.js
+++ b/lib/sendgrid.js
@@ -2,6 +2,7 @@
 
 var package_json    = require('./../package.json');
 var nodemailer      = require('nodemailer');
+var _               = require('underscore');
 var request         = require('request');
 var Email           = require('./email');
 var SmtpapiHeaders  = require('./smtpapi_headers');
@@ -37,20 +38,29 @@ module.exports = function(api_user, api_key) {
    * Sends an email via SMTP and returns true if the
    * message was sent successfully.
    *
-   * @param    {Email|Object}  email     An email object or a hash that has
-   *                                     the values for the email to be sent.
-   * @param    {Function}      callback  A function to call when the processing is done.
-   *                                     This parameter is optional.
+   * @param    {Email|Object}  email                     An email object or a hash that has
+   *                                                     the values for the email to be sent.
+   * @param    {Object}        nodeMailerOptions         Extra options for nodeMailer. i.e. Message-Id
+   *                                                     This parameter is optional.
+   * @param    {Function}      callback                  A function to call when the processing is done.
+   *                                                     This parameter is optional.
    */
-  var smtp = function(email, callback) {
+  var smtp = function(email, nodeMailerOptions, callback) {
     self            = this;
-    var callback    = callback || function() { };
+
+    // Support a callback without nodeMailerOptions
+    if (! callback && typeof nodeMailerOptions === "function") {
+      callback = nodeMailerOptions;
+      nodeMailerOptions = null;
+    }
+
+    var callback = callback || function() { };
 
     if (email.constructor !== Email) {
       email = new Email(email);
     }
 
-    _sendSmtp(email, callback);
+    _sendSmtp(email, nodeMailerOptions, callback);
   };
 
   /*
@@ -93,7 +103,7 @@ module.exports = function(api_user, api_key) {
     }
   }
 
-  var _sendSmtp = function(email, callback) {
+  var _sendSmtp = function(email, nodeMailerOptions, callback) {
     // SMTP settings
     var smtp_settings = {
       host: "smtp.sendgrid.net",
@@ -110,7 +120,13 @@ module.exports = function(api_user, api_key) {
 
     var smtpTransport = nodemailer.createTransport(self.SMTP, smtp_settings);
 
-    smtpTransport.sendMail(email.toSmtpFormat(), function(error, response) {
+    var smtpParams = email.toSmtpFormat();
+
+    if (_.isObject(nodeMailerOptions)) {
+      _.extend(smtpParams, nodeMailerOptions);
+    }
+
+    smtpTransport.sendMail(smtpParams, function(error, response) {
       smtpTransport.close();
       if(error) { return callback(new Error(error.data), null);}
 
@@ -127,7 +143,7 @@ module.exports = function(api_user, api_key) {
     port            : 587,
     SMTP            : "SMTP",
     Email           : Email,
-    SmtpapiHeaders  : SmtpapiHeaders, 
+    SmtpapiHeaders  : SmtpapiHeaders,
     api_user        : api_user,
     api_key         : api_key,
     web             : web,


### PR DESCRIPTION
PR for Issue #74 - lets you pass nodemailer additional options for the outbound email, such as the Message-Id.  

See https://github.com/andris9/Nodemailer#e-mail-message-fields for options.

@scottmotte, I'm not sure how to write mocks against the SMTP stuff, so sorry, there's not a test included in this PR.
