### PR TITLE
Show the error's message

### DIFF
--- a/lib/sendgrid.js
+++ b/lib/sendgrid.js
@@ -142,7 +142,7 @@ var Sendgrid = function(api_user, api_key, options) {
 
     smtpTransport.sendMail(smtpParams, function(error, response) {
       smtpTransport.close();
-      if(error) { return callback(new Error(error.data), null);}
+      if(error) { return callback(new Error(error.message), null);}
 
       return callback(null, {'message': 'success'});
     });


### PR DESCRIPTION
I don't know what error.data is, but it wasn't populating the error's message for me.  This fix does.  

Fixes issue #88

FWIW: Another way to generate an error is to use a to: that's not an email address.
