### PR TITLE
Update smtpapi_headers.js to improve addSubVal functions

### DIFF
--- a/lib/smtpapi_headers.js
+++ b/lib/smtpapi_headers.js
@@ -21,6 +21,9 @@ SmtpapiHeaders.prototype.addSubVal = function(key, val) {
   if (_.isArray(val)) {
     this.sub[key] = val;
   } else {
+      if(this.sub[key])
+          this.sub[key].push(val);
+      else
     this.sub[key] = [val];
   }
 }


### PR DESCRIPTION
addSubVal function was replacing old values for same key by new value in subsequent calls.
addTo function supports adding multiple recipients one by one but addSubVal function was missing similar functionality. 
fixed error in addsubVal function.
