### PR TITLE
remove hardcoded shrinkwrap dependency resolution to main npm registry.

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -55,7 +55,6 @@
     "request": {
       "version": "2.22.0",
       "from": "request@2.22.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.22.0.tgz",
       "dependencies": {
         "qs": {
           "version": "0.6.5",


### PR DESCRIPTION
With a hardcoded `resolve` in the shrinkwrap file it is library impossible to use an npm dependency if npm is set to use anything other than the main/default registry because this happens (see below).

``` bash
 ~/code/sendgrid-nodejs  ± master   npm --registry http://registry.npmjs.eu/ install
npm http GET http://registry.npmjs.eu/dotenv/0.0.2
npm http GET http://registry.npmjs.eu/lodash/2.0.0
npm http GET https://registry.npmjs.org/request/-/request-2.22.0.tgz
npm http GET http://registry.npmjs.eu/mocha
npm http GET http://registry.npmjs.eu/chai
npm http GET http://registry.npmjs.eu/nock
npm http GET http://registry.npmjs.eu/nodemailer/0.4.4
npm http GET http://registry.npmjs.eu/mime/1.2.9
npm http GET http://registry.npmjs.eu/sinon
npm http 200 http://registry.npmjs.eu/dotenv/0.0.2
npm http GET http://registry.npmjs.eu/dotenv/-/dotenv-0.0.2.tgz
npm http 200 http://registry.npmjs.eu/lodash/2.0.0
npm http GET http://registry.npmjs.eu/lodash/-/lodash-2.0.0.tgz
npm http 200 http://registry.npmjs.eu/mime/1.2.9
npm http GET http://registry.npmjs.eu/mime/-/mime-1.2.9.tgz
npm http 200 http://registry.npmjs.eu/nodemailer/0.4.4
npm http GET http://registry.npmjs.eu/nodemailer/-/nodemailer-0.4.4.tgz
npm http 200 http://registry.npmjs.eu/mocha
npm http 200 http://registry.npmjs.eu/chai
npm http 200 http://registry.npmjs.eu/dotenv/-/dotenv-0.0.2.tgz
npm http 200 http://registry.npmjs.eu/lodash/-/lodash-2.0.0.tgz
npm http GET http://registry.npmjs.eu/chai/-/chai-1.8.1.tgz
npm http 200 http://registry.npmjs.eu/sinon
npm http 200 http://registry.npmjs.eu/mime/-/mime-1.2.9.tgz
npm http 200 http://registry.npmjs.eu/nodemailer/-/nodemailer-0.4.4.tgz
npm http 200 http://registry.npmjs.eu/chai/-/chai-1.8.1.tgz
npm ERR! fetch failed https://registry.npmjs.org/request/-/request-2.22.0.tgz
npm http 200 http://registry.npmjs.eu/nock
npm http GET https://registry.npmjs.org/request/-/request-2.22.0.tgz
npm ERR! fetch failed https://registry.npmjs.org/request/-/request-2.22.0.tgz
npm http GET https://registry.npmjs.org/request/-/request-2.22.0.tgz
npm ERR! fetch failed https://registry.npmjs.org/request/-/request-2.22.0.tgz
npm ERR! Error: UNABLE_TO_VERIFY_LEAF_SIGNATURE
npm ERR!     at SecurePair.<anonymous> (tls.js:1356:32)
npm ERR!     at SecurePair.EventEmitter.emit (events.js:92:17)
npm ERR!     at SecurePair.maybeInitFinished (tls.js:968:10)
npm ERR!     at CleartextStream.read [as _read] (tls.js:462:15)
npm ERR!     at CleartextStream.Readable.read (_stream_readable.js:320:10)
npm ERR!     at EncryptedStream.write [as _write] (tls.js:366:25)
npm ERR!     at doWrite (_stream_writable.js:221:10)
npm ERR!     at writeOrBuffer (_stream_writable.js:211:5)
npm ERR!     at EncryptedStream.Writable.write (_stream_writable.js:180:11)
npm ERR!     at write (_stream_readable.js:583:24)
npm ERR! If you need help, you may report this log at:
npm ERR!     <http://github.com/isaacs/npm/issues>
npm ERR! or email it to:
npm ERR!     <npm-@googlegroups.com>

npm ERR! System Darwin 13.0.0
npm ERR! command "/usr/local/Cellar/node/0.10.21/bin/node" "/usr/local/bin/npm" "--registry" "http://registry.npmjs.eu/" "install"
npm ERR! cwd /Users/sandfox/code/sendgrid-nodejs
npm ERR! node -v v0.10.21
npm ERR! npm -v 1.3.11
npm ERR!
npm ERR! Additional logging details can be found in:
npm ERR!     /Users/sandfox/code/sendgrid-nodejs/npm-debug.log
npm ERR! not ok code 0
```
