### PR TITLE
added ability to change uri via options

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,21 @@ email.addHtml('<div>Our logo:<img src="cid:the_logo"></div>');
 
 ## Options
 
+### Changing URL
+You may change the URL sendgrid-nodejs uses to send email by supplying various parameters to `options`, all parameters are optional:
+
+```javascript
+var sendgrid = require('sendgrid')('username', 'password', { "protocol" : "http", "host" : "sendgrid.org", "endpoint" : "/send", "port" : "80" });
+```
+
+A full URI may also be provided:
+
+```javascript
+var sendgrid = require('sendgrid')('username', 'password', { "uri" : "http://sendgrid.org:80/send" });
+```
+
+### Request
+
 sendgrid-nodejs uses the node request module. You can pass in options
 to be merged. This enables you to use your own https.Agent, node-tunnel
 or the request proxy url. Please note that sendgrid requires https.

--- a/lib/sendgrid.js
+++ b/lib/sendgrid.js
@@ -12,6 +12,20 @@ var Sendgrid = function(api_user, api_key, options) {
 
   var _this         = this;
   this.options      = options || {};
+  
+  // do this to mantain similarity to other libs
+  var uriParts = {};
+  uriParts.protocol = this.options.protocol || "https";
+  uriParts.host = this.options.host || "api.sendgrid.com";
+  uriParts.port = this.options.port || "";
+  uriParts.endpoint = this.options.endpoint || "/api/mail.send.json";
+  delete this.options.protocol;
+  delete this.options.host;
+  delete this.options.port;
+  delete this.options.endpoint;
+  this.options.uriParts = uriParts;
+
+  this.options.uri = this.options.uri || uriParts.protocol + "://" + uriParts.host + (uriParts.port ? ":" + uriParts.port : "") + uriParts.endpoint;
 
   var send = function(email, callback) {
     var callback    = callback || function() { };
@@ -24,11 +38,10 @@ var Sendgrid = function(api_user, api_key, options) {
 
   var _send = function(email, callback) {
     var postOptions = {
-      method    : 'POST',
-      uri       : "https://api.sendgrid.com/api/mail.send.json"
+      method    : 'POST'
     };
 
-    var options = _.merge(this.options, postOptions);
+    var options = _.merge(postOptions, this.options);
 
     var req   = request(options, function(err, resp, body) {
       var json;

--- a/test/lib/sendgrid.test.js
+++ b/test/lib/sendgrid.test.js
@@ -22,6 +22,16 @@ describe('SendGrid', function () {
     expect( typeof sendgrid.options).to.equal('object');
   });
 
+  it('should have uri set to the default', function() {
+    expect(sendgrid.options.uri).to.equal("https://api.sendgrid.com/api/mail.send.json");
+  });
+
+  it('should allow uri to change', function() {
+    var options   = { "protocol" : "http", "host" : "sendgrid.org", "endpoint" : "/send", "port" : "80" };
+    var sendgrid2 = require('../../lib/sendgrid')(API_USER, API_KEY, options);
+    expect(sendgrid2.options.uri).to.equal("http://sendgrid.org:80/send");
+  });
+
   it('should have web options agent global', function() {
     var options   = { web: { pool: global.http.globalAgent } };
     var sendgrid2 = require('../../lib/sendgrid')(API_USER, API_KEY, options);


### PR DESCRIPTION
this brings the library in line with: https://github.com/scottmotte/sendgrid-opensource-proposals/blob/master/proposals/PORT.md

as this uses parameters that also could be used by request, this may cause problems with those using the protocol parameter (however, I believe that any use of the protocol parameter in the past, would not have worked, anyway)
