### PR TITLE
Permit lodash version 3 to also be acceptable within npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "mime": "^1.2.9",
     "request": "^2.40.0",
-    "lodash": "^2.0.0",
+    "lodash": "^3.0.1 || ^2.0.0",
     "smtpapi": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The sendgrid-nodejs project leverages the following lodash functions:
* isObject
* extend
* isEmpty
* merge

Based on the [lodash changelog](https://github.com/lodash/lodash/wiki/Changelog), `_.isObject` had some optimizations and `_.merge` had some sanity checks introduced (which wouldn't impact the usage within `sendgrid.js`).

All tests pass.

This PR tells sendgrid to permit both the v2 and v3 of lodash, but tells it to prefer the v3 branch.