### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,5 +36,6 @@
     "test": "./node_modules/.bin/mocha --grep '#skip' --invert",
     "skipped": "./node_modules/.bin/mocha --grep '#skip'"
   },
+  "license": "MIT",
   "optionalDependencies": {}
 }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/