### PR TITLE
Add 'return this' for setter method chaining

### DIFF
--- a/lib/email.js
+++ b/lib/email.js
@@ -48,116 +48,144 @@ Email.prototype.addHeader = function(object_literal_or_key, value) {
     object_to_add[object_literal_or_key] = value;
     _.extend(this.headers, object_to_add);
   }
+  return this;
 };
 
 Email.prototype.setHeaders = function(object_literal) {
   if (_.isObject(object_literal)) {
     this.headers = object_literal;
   }
+  return this;
 };
 
 Email.prototype.addTo = function(to) {
   this.smtpapi.addTo(to);
+  return this;
 };
 
 Email.prototype.setTos = function(tos) {
   this.smtpapi.setTos(tos);
+  return this;
 };
 
 Email.prototype.setFrom = function(from) {
   this.from = from;
+  return this;
 };
 
 Email.prototype.addCc = function(cc) {
   this.cc.push(cc);
+  return this;
 };
 
 Email.prototype.setCcs = function(cc) {
   this.cc = cc;
+  return this;
 };
 
 Email.prototype.addBcc = function(bcc) {
   this.bcc.push(bcc);
+  return this;
 };
 
 Email.prototype.setBccs = function(bcc) {
   this.bcc = bcc;
+  return this;
 };
 
 Email.prototype.setSubject = function(subject) {
   this.subject = subject;
+  return this;
 };
 
 Email.prototype.setText = function(text) {
   this.text = text;
+  return this;
 };
 
 Email.prototype.setHtml = function(html) {
   this.html = html;
+  return this;
 };
 
 Email.prototype.addSubstitution = function(key, val) {
   this.smtpapi.addSubstitution(key, val);
+  return this;
 };
 
 Email.prototype.setSubstitutions = function(substitutions) {
   this.smtpapi.setSubstitutions(substitutions);
+  return this;
 };
 
 Email.prototype.addUniqueArg = function (key, val) {
   this.smtpapi.addUniqueArg(key, val);
+  return this;
 };
 
 Email.prototype.setUniqueArgs = function(object_literal) {
   this.smtpapi.setUniqueArgs(object_literal);
+  return this;
 };
 
 Email.prototype.addCategory = function(val) {
   this.smtpapi.addCategory(val);
+  return this;
 };
 
 Email.prototype.setCategories = function(val) {
   this.smtpapi.setCategories(val);
+  return this;
 };
 
 Email.prototype.addSection = function(key, val) {
   this.smtpapi.addSection(key, val);
+  return this;
 };
 
 Email.prototype.setSections = function(object_literal) {
   this.smtpapi.setSections(object_literal);
+  return this;
 };
 
 Email.prototype.addFilter = function(filter, setting, val) {
   this.smtpapi.addFilter(filter, setting, val);
+  return this;
 };
 
 Email.prototype.setFilters = function(filters) {
   this.smtpapi.setFilters(filters);
+  return this;
 };
 
 Email.prototype.setASMGroupID = function(val) {
   this.smtpapi.setASMGroupID(val);
+  return this;
 };
 
 Email.prototype.addFile = function(file_object) {
   this.files.push(new FileHandler(file_object));
+  return this;
 };
 
 Email.prototype.setDate = function(date) {
   this.date = date;
+  return this;
 };
 
 Email.prototype.setSendAt = function(send_at) {
   this.smtpapi.setSendAt(send_at);
+  return this;
 };
 
 Email.prototype.setSendEachAt = function(send_each_at) {
   this.smtpapi.setSendEachAt(send_each_at);
+  return this;
 };
 
 Email.prototype.addSendEachAt = function(send_each_at) {
   this.smtpapi.addSendEachAt(send_each_at);
+  return this;
 };
 
 Email.prototype.toWebFormat = function() {


### PR DESCRIPTION
This pull request enables setter method chaining as follows like sendgrid-java.
```js
var sendgrid  = require('sendgrid')(api_user, api_key);
email = new sendgrid.Email()
  .addTo('example@example.com')
  .setFrom('other@example.com')
  .setSubject('Hello World')
  .setText('My first email through SendGrid.');
```