### PR TITLE
Require just used functions & use natives

### DIFF
--- a/lib/email.js
+++ b/lib/email.js
@@ -2,7 +2,8 @@
 
 var FileHandler     = require('./file_handler');
 var smtpapi_lib     = require('smtpapi');
-var _               = require('lodash');
+var isObject        = require('lodash/lang/isObject');
+var extend          = require('lodash/object/assign');
 var request         = require('request');
 var fs              = require('fs');
 
@@ -37,22 +38,22 @@ function Email(params) {
 }
 
 Email.prototype.addHeader = function(object_literal_or_key, value) {
-  if (typeof value === "undefined" || value === null) { 
-    value = ""; 
+  if (typeof value === "undefined" || value === null) {
+    value = "";
   }
 
-  if (_.isObject(object_literal_or_key)) {
-    _.extend(this.headers, object_literal_or_key);
+  if (isObject(object_literal_or_key)) {
+    extend(this.headers, object_literal_or_key);
   } else {
     var object_to_add = {}
     object_to_add[object_literal_or_key] = value;
-    _.extend(this.headers, object_to_add);
+    extend(this.headers, object_to_add);
   }
   return this;
 };
 
 Email.prototype.setHeaders = function(object_literal) {
-  if (_.isObject(object_literal)) {
+  if (isObject(object_literal)) {
     this.headers = object_literal;
   }
   return this;

--- a/lib/file_handler.js
+++ b/lib/file_handler.js
@@ -2,7 +2,7 @@
 
 var http = require('http');
 var mime = require('mime');
-var _ = require('lodash');
+var isEmpty = require('lodash/lang/isEmpty');
 var url = require('url');
 var fs = require('fs');
 
@@ -42,7 +42,7 @@ function FileHandler(file_object) {
     if (!this.filename) {
       this.filename = file_object.path.split('\/').pop();
     }
-    if (_.isEmpty(file_object.contentType)) {
+    if (isEmpty(file_object.contentType)) {
       this.contentType = mime.lookup(this.path);
     }
   } else if (file_object.url) {
@@ -97,7 +97,7 @@ FileHandler.handlers = {
       res.on('end', function() {
         var buffer = new Buffer(totalBufferSize, 'base64');
         var bufPos = 0;
-        _(bufferArray).each(function(val) {
+        bufferArray.forEach(function(val) {
           bufPos += buffer.write(val, bufPos, 'base64');
         });
         file.content = buffer;

--- a/lib/sendgrid.js
+++ b/lib/sendgrid.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var package_json    = require('./../package.json');
-var _               = require('lodash');
+var merge           = require('lodash/object/merge');
 var request         = require('request');
 var smtpapi_lib     = require('smtpapi');
 var Email           = require('./email');
@@ -30,7 +30,7 @@ var Sendgrid = function(apiUserOrKey, apiKeyOrOptions, options) {
   }
 
   var _this         = this;
-  
+
   // do this to mantain similarity to other libs
   var uriParts = {};
   uriParts.protocol = this.options.protocol || "https";
@@ -67,13 +67,13 @@ var Sendgrid = function(apiUserOrKey, apiKeyOrOptions, options) {
       postOptions.headers['Authorization'] = 'Bearer ' + this.api_key;
     }
 
-    var options = _.merge(postOptions, this.options);
+    var options = merge(postOptions, this.options);
 
     var req = request(options, function(err, resp, body) {
       var json;
 
       if(err) return callback(err, null);
-      
+
       try {
         json = JSON.parse(body);
       } catch (e) {

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "node": ">= 0.4.7"
   },
   "dependencies": {
+    "lodash": "^3.10.0",
     "mime": "^1.2.9",
     "request": "^2.60.0",
-    "lodash": "^3.0.1 || ^2.0.0",
     "smtpapi": "^1.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi,

I made this because after a few requests using this module, lodash was causing some memory allocation problems, the full file is very big and it was causing me problems.

I don't quite understand why, but make just these changes, requiring just the used functions and using a few native functions, my application decrease the memory allocation quite a lot.