### PR TITLE
README: show sample json output for successful email send.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ sendgrid.send({
 }, function(err, json) {
   if (err) { return console.error(err); }
   console.log(json);
+  // console output if successful: { message: 'success' }
 });
 ```
 
@@ -93,6 +94,7 @@ Send it.
 sendgrid.send(payload, function(err, json) {
   if (err) { console.error(err); }
   console.log(json);
+  // console output if successful: { message: 'success' }
 });
 ```
 
@@ -123,6 +125,7 @@ var email     = new sendgrid.Email({
 sendgrid.send(email, function(err, json) {
   if (err) { return console.error(err); }
   console.log(json);
+  // console output if successful: { message: 'success' }
 });
 ```
 
@@ -178,7 +181,7 @@ You can add one or multiple TO addresses using `addTo`.
 **Note**: One of the most notable changes is how `addTo()` behaves. We are now using our Web API parameters instead of the X-SMTPAPI header. What this means is that if you call `addTo()` multiple times for an email, **ONE** email will be sent with each email address visible to everyone. In oder to use the header, please call the `addSmtpapiTo()` method.
 
 ```javascript
-var email     = new sendgrid.Email(); 
+var email     = new sendgrid.Email();
 email.addTo('foo@bar.com');
 email.addTo('another@another.com');
 sendgrid.send(email, function(err, json) { });
@@ -191,14 +194,14 @@ sendgrid.send(email, function(err, json) { });
 var email = new sendgrid.Email()
 email.addSmtpapiTo('test@test.com');
 sendgrid.send(email, function(err, json) { });
-``` 
+```
 
 #### setTos
 
 **Note**: The `setTos()` method now utilizes the Web API as opposed to using the X-SMTPAPI header. Please refer to the note posted on the top of this page. In order to use the header, you will need to use the `setSmtpapiTos()` method.
 
 ```javascript
-var email     = new sendgrid.Email(); 
+var email     = new sendgrid.Email();
 email.setTos(['foo@bar.com', 'another@another.com']);
 sendgrid.send(email, function(err, json) { });
 ```
@@ -214,7 +217,7 @@ sendgrid.send(email, function(err, json) { });
 #### setFrom
 
 ```javascript
-var email     = new sendgrid.Email(); 
+var email     = new sendgrid.Email();
 email.setFrom('foo@bar.com');
 sendgrid.send(email, function(err, json) { });
 ```
@@ -222,7 +225,7 @@ sendgrid.send(email, function(err, json) { });
 #### setFromName
 
 ```javascript
-var email     = new sendgrid.Email(); 
+var email     = new sendgrid.Email();
 email.setFromName('Bob Bar');
 sendgrid.send(email, function(err, json) { });
 ```
@@ -272,7 +275,7 @@ sendgrid.send(email, function(err, json) { });
 #### setSubject
 
 ```javascript
-var email     = new sendgrid.Email(); 
+var email     = new sendgrid.Email();
 email.setSubject('Some subject');
 sendgrid.send(email, function(err, json) { });
 ```
@@ -280,7 +283,7 @@ sendgrid.send(email, function(err, json) { });
 #### setText
 
 ```javascript
-var email     = new sendgrid.Email(); 
+var email     = new sendgrid.Email();
 email.setText('Some text');
 sendgrid.send(email, function(err, json) { });
 ```
@@ -288,7 +291,7 @@ sendgrid.send(email, function(err, json) { });
 #### setHtml
 
 ```javascript
-var email     = new sendgrid.Email(); 
+var email     = new sendgrid.Email();
 email.setHtml('<h1>Some html</h1>');
 sendgrid.send(email, function(err, json) { });
 ```
@@ -331,7 +334,7 @@ sendgrid.send(email, function(err, json) { });
 You can add custom headers. This will ADD rather than SET headers.
 
 ```javascript
-var email     = new sendgrid.Email(); 
+var email     = new sendgrid.Email();
 email.setHeaders({full: 'hearts'});   // headers = {full: 'hearts'}
 email.addHeader('spin', 'attack');   // headers = {full: 'hearts', spin: 'attack'}
 email.addHeader('mask', 'salesman'); // headers = {full: 'hearts', spin: 'attack', mask: 'salesman'}
@@ -340,10 +343,10 @@ sendgrid.send(email, function(err, json) { });
 
 #### setHeaders
 
-You can set custom headers. 
+You can set custom headers.
 
 ```javascript
-var email     = new sendgrid.Email(); 
+var email     = new sendgrid.Email();
 email.setHeaders({full: 'hearts'});   // headers = {full: 'hearts'}
 email.setHeaders({mask: 'salesman'}); // headers = {mask: 'salesman'}
 sendgrid.send(email, function(err, json) { });
@@ -371,7 +374,7 @@ var email     = new sendgrid.Email();
 email.addSection('-charge-', 'This ship is useless.'); // section = {'-charge-': 'This ship is useless.'}
 ```
 
-#### setSections 
+#### setSections
 
 ```javascript
 var email     = new sendgrid.Email();
@@ -493,11 +496,11 @@ email.subject = "Send with templates app";
 email.from = 'from@example.com';
 email.text = 'Hi there!';
 email.html = '<h1>Hi there!</h1>';
- 
+
 // add filter settings one at a time
 email.addFilter('templates', 'enable', 1);
 email.addFilter('templates', 'template_id', '09c6ab89-9157-4710-8ca4-db7927c631d6');
- 
+
 // or set a filter using an object literal.
 email.setFilters({
     'templates': {


### PR DESCRIPTION
The sample does not indicate what json gets returned if the message was successful sending:
![screen shot 2015-12-02 at 1 13 02 pm](https://cloud.githubusercontent.com/assets/8163408/11544403/8134ede0-98f6-11e5-81ea-e2493e11bd59.png)

As a user, I wondered what the json output of a successful message would be: the original message, a send receipt, my sendgrid quota data?

My change adds comments at the samples showing that json should be `{ message: 'success '}` on success.
![screen shot 2015-12-02 at 1 16 46 pm](https://cloud.githubusercontent.com/assets/8163408/11544493/011df2f4-98f7-11e5-997e-9d0982a7917c.png)

Additionally, I removed all unneccessary, trailing whitespace using Sublime whitespace highlighter:
![screen shot 2015-12-02 at 1 36 21 pm](https://cloud.githubusercontent.com/assets/8163408/11545002/bf59755c-98f9-11e5-9c97-065ceb01a3c6.png)

### Summary of Changes
- In README
  - Added output for `console.log(json)`
  - Removed trailing whitespaces