### PR TITLE
Fix 'this' binding in initialization.

### DIFF
--- a/lib/sendgrid.js
+++ b/lib/sendgrid.js
@@ -30,7 +30,7 @@ var Sendgrid = function(apiUserOrKey, apiKeyOrOptions, options) {
   }
 
   var _this         = this;
-  
+
   // do this to mantain similarity to other libs
   var uriParts = {};
   uriParts.protocol = this.options.protocol || "https";
@@ -51,7 +51,7 @@ var Sendgrid = function(apiUserOrKey, apiKeyOrOptions, options) {
       email = new Email(email);
     }
 
-    _send.bind(this)(email, callback);
+    _send.bind(_this)(email, callback);
   };
 
   var _send = function(email, callback) {
@@ -73,7 +73,7 @@ var Sendgrid = function(apiUserOrKey, apiKeyOrOptions, options) {
       var json;
 
       if(err) return callback(err, null);
-      
+
       try {
         json = JSON.parse(body);
       } catch (e) {


### PR DESCRIPTION
Use _this instead of this to bind to _send on initialization.

I needed this change for the library to work here. Otherwise, in send(), this.options would be undefined because 'this' wasn't bound correctly. This caused the problem that no URI would be passed to request, which would complain with an error like "options.uri is a required option".

Does this work for everyone else? Because without this change I couldn't use the library at all, since all calls to send() would fail with that error.

I'm using node v0.10.25 and sendgrid 2.0.0. This node version is a bit old, but theoretically allowed by sendgrid's package.json, which only asks for a version >= 0.4.7.

Thanks.