### PR TITLE
added read stream support + test

### DIFF
--- a/lib/email.js
+++ b/lib/email.js
@@ -231,6 +231,8 @@ Email.prototype.toWebFormat = function() {
         file.content  = request(file.url);
       } else if (file.path) {
         file.content  = fs.createReadStream(file.path);
+      } else if (file.stream) {
+        file.content = file.stream;
       }
 
       web['files[' + file.filename + ']'] = {

--- a/lib/file_handler.js
+++ b/lib/file_handler.js
@@ -9,15 +9,16 @@ var fs = require('fs');
 /**
  * Class to handle file attachments on an email.
  *
- * @param  {object}  file_object              Options to create a FileHandler
- * @param  {string}  file_object.filename     The name of the file to send.
- *                                            This will be guessed based on the file added
- *                                            if blank.
- * @param  {string}  file_object.contentType  The Content-Type of the file.
- * @param  {string}  file_object.content      The content to send in the file (usually a Buffer)
- * @param  {string}  file_object.cid          The cid to use for inline content
- * @param  {string}  file_object.path         The absolute path of the file on the filesystem
- * @param  {string}  file_object.url          The url to fetch a file from before sending
+ * @param  {object}  file_object                 Options to create a FileHandler
+ * @param  {string}  file_object.filename        The name of the file to send.
+ *                                               This will be guessed based on the file added
+ *                                               if blank.
+ * @param  {string}  file_object.contentType     The Content-Type of the file.
+ * @param  {string}  file_object.content         The content to send in the file (usually a Buffer)
+ * @param  {string}  file_object.cid             The cid to use for inline content
+ * @param  {string}  file_object.path            The absolute path of the file on the filesystem
+ * @param  {string}  file_object.url             The url to fetch a file from before sending
+ * @param  {string}  file_object.stream          The readstream that will give the contents for the file
  */
 function FileHandler(file_object) {
   this.filename = file_object.filename;
@@ -50,6 +51,12 @@ function FileHandler(file_object) {
     this.url = file_object.url;
     if (!this.contentType) {
       this.contentType = mime.lookup(this.url);
+    }
+  } else if (file_object.stream) {
+    this.type = 'stream';
+    this.stream = file_object.stream;
+    if (!this.contentType) {
+      this.contentType = mime.lookup(this.filename);
     }
   } else {
     this.type = 'none';
@@ -110,6 +117,16 @@ FileHandler.handlers = {
     });
 
     req.end();
+  },
+  stream: function(file, callback) {
+    if (file.stream) {
+      file.content = file.stream;
+      process.nextTick(function () {
+        callback();
+      });
+    } else {
+      callback(true, 'Stream was missing');
+    }
   },
   none: function(file, callback) {
     callback(true, 'File was not included');

--- a/test/lib/email.test.js
+++ b/test/lib/email.test.js
@@ -394,6 +394,17 @@ describe('Email', function () {
         expect(email.files[0].contentType).to.equal('image/png');
       });
     });
+
+    it('should support attachments via readstream', function () {
+      var fileReadStream = fs.createReadStream(__filename)
+      var email = new Email();
+      email.addFile({
+        stream: fileReadStream,
+        contentType: 'text/javascript'
+      });
+      expect(email.files[0].stream).to.equal(fileReadStream);
+      expect(email.files[0].contentType).to.equal('text/javascript');
+    });
   });
 
   describe('custom headers', function() {
@@ -487,6 +498,25 @@ describe('Email', function () {
       });
 
       email.files[0].loadContent(function(error, message) {
+        expect(error).to.not.be.true;
+        expect(email.files[0].content).to.not.be.undefined;
+        done();
+      });
+    });
+
+    it('should be able to add readstream files easily', function (done) {
+      var file = {
+        stream: fs.createReadStream(__filename),
+        contentType: 'text/javascript'
+      }
+
+      var email = new Email({
+        files: [
+          file
+        ]
+      });
+
+      email.files[0].loadContent(function (error, message) {
         expect(error).to.not.be.true;
         expect(email.files[0].content).to.not.be.undefined;
         done();

--- a/test/lib/file_handler.test.js
+++ b/test/lib/file_handler.test.js
@@ -1,3 +1,4 @@
+var fs = require('fs');
 var FileHandler = require('../../lib/file_handler');
 
 describe('FileHandler', function() {
@@ -58,6 +59,17 @@ describe('FileHandler', function() {
 
     expect(handler.filename).to.equal('test');
     expect(handler.type).to.equal('none');
+  });
+
+  it('should handle readstreams', function () {
+    var currentFileReadStream = fs.createReadStream(__filename);
+    var handler = new FileHandler({
+      stream: currentFileReadStream,
+      contentType: 'text/javascript'
+    });
+
+    expect(handler.stream).to.equal(currentFileReadStream);
+    expect(handler.contentType).to.equal('text/javascript');
   });
 
   it('should handle inline content', function() {


### PR DESCRIPTION
[Issue-148](https://github.com/sendgrid/sendgrid-nodejs/issues/148)
Adds ReadStream support for email attachments

Possible Use Case:
- Generating PDFs from within node app. Many PDF generation libraries in node return the result pdf as a ReadStream. If one wanted to attach the generated PDF to an email, they would need to save the PDF locally and then give the `Email` object the path to the file. With this, there is an intermediary step of storing the stream contents into a file, and then attaching the file to the email. With this pull request, you can attach it directly with the `stream` option:

```
var pdfStream = generatePDFStream({ ... });
email.addFile({
  filename: 'foo.pdf',
  contentType: 'application/pdf',
  stream: pdfStream
});
```