### PR TITLE
switch to mime-types package

### DIFF
--- a/lib/file_handler.js
+++ b/lib/file_handler.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var http = require('http');
-var mime = require('mime');
+var mime = require('mime-types');
 var _ = require('lodash');
 var url = require('url');
 var fs = require('fs');

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "node": ">= 0.4.7"
   },
   "dependencies": {
-    "mime": "^1.2.9",
+    "mime-types": "^2.1.10",
     "request": "^2.60.0",
     "lodash": "^3.0.1 || ^2.0.0",
     "smtpapi": "^1.2.0"


### PR DESCRIPTION
We're Webpack to bundle/minify dependencies for AWS Lambda, but were unable to to include Sendgrid due to the older version of `node-mime`.

This switches to `mime-types` + `mime-db` and should also resolve #207.