### PR TITLE
Promise API and consistent callback function signature

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+node_modules
+examples
+test

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -1,0 +1,136 @@
+root: true
+extends: eslint:recommended
+parserOptions:
+  ecmaVersion: 6
+  ecmaFeatures:
+    impliedStrict: true
+  sourceType: module
+env:
+  es6: true
+  node: true
+  mocha: true
+  jasmine: true
+rules:
+  linebreak-style:
+    - error
+    - unix
+  max-len:
+    - warn
+    - code: 80
+      tabWidth: 2
+      ignoreComments: true
+      ignoreUrls: true
+  indent:
+    - error
+    - 2
+    - SwitchCase: 1
+      VariableDeclarator:
+        let: 2
+        const: 3
+  semi:
+    - error
+    - always
+  consistent-this:
+    - error
+    - self
+    - $ctrl
+  quotes:
+    - error
+    - single
+    - allowTemplateLiterals: true
+  curly:
+    - error
+    - all
+  comma-dangle:
+    - error
+    - always-multiline
+  new-cap:
+    - error
+    - newIsCap: true
+      capIsNew: true
+      properties: false
+  array-bracket-spacing:
+    - error
+    - never
+  arrow-spacing:
+    - error
+    - before: true
+      after: true
+  block-spacing:
+    - error
+    - always
+  comma-spacing:
+    - error
+    - before: false
+      after: true
+  computed-property-spacing:
+    - error
+    - never
+  generator-star-spacing:
+    - error
+    - before: true
+      after: false
+  key-spacing:
+    - error
+    - beforeColon: false
+      afterColon: true
+      mode: minimum
+  keyword-spacing:
+    - error
+    - before: true
+  semi-spacing:
+    - error
+    - before: false
+      after: true
+  space-in-parens:
+    - error
+    - never
+  space-unary-ops:
+    - error
+    - words: true
+      nonwords: false
+  space-before-function-paren:
+    - error
+    - never
+  space-before-blocks:
+    - error
+    - always
+  yoda:
+    - error
+    - never
+  wrap-iife:
+    - error
+    - outside
+  eqeqeq:
+    - error
+    - always
+  newline-per-chained-call:
+    - error
+    - ignoreChainWithDepth: 3
+  one-var-declaration-per-line:
+    - error
+    - initializations
+  brace-style:
+    - error
+    - stroustrup
+  no-implicit-coercion:
+    - error
+    - boolean: false
+  no-multiple-empty-lines:
+    - error
+    - max: 1
+  eol-last: error
+  dot-notation: error
+  space-infix-ops: error
+  no-with: error
+  no-unreachable: error
+  no-redeclare: error
+  no-unexpected-multiline: error
+  no-multi-spaces: error
+  no-multi-str: error
+  no-trailing-spaces: error
+  no-mixed-spaces-and-tabs: error
+  no-spaced-func: error
+  no-whitespace-before-property: error
+  no-lonely-if: error
+  no-console: off

--- a/README.md
+++ b/README.md
@@ -71,19 +71,20 @@ The following is the minimum needed code to send an email with the [/mail/send H
 
 ```javascript
   var helper = require('sendgrid').mail
-  from_email = new helper.Email("test@example.com")
-  to_email = new helper.Email("test@example.com")
-  subject = "Hello World from the SendGrid Node.js Library!"
-  content = new helper.Content("text/plain", "Hello, Email!")
+  from_email = new helper.Email('test@example.com')
+  to_email = new helper.Email('test@example.com')
+  subject = 'Hello World from the SendGrid Node.js Library!'
+  content = new helper.Content('text/plain', 'Hello, Email!')
   mail = new helper.Mail(from_email, subject, to_email, content)
 
-  var sg = require('sendgrid').SendGrid(process.env.SENDGRID_API_KEY)
-  var requestBody = mail.toJSON()
-  var request = sg.emptyRequest()
-  request.method = 'POST'
-  request.path = '/v3/mail/send'
-  request.body = requestBody
-  sg.API(request, function (error, response) {
+  var sg = require('sendgrid')(process.env.SENDGRID_API_KEY);
+  var request = sg.emptyRequest({
+    method: 'POST',
+    path: '/v3/mail/send',
+    body: mail.toJSON()
+  });
+
+  sg.API(request, function(error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -97,42 +98,61 @@ The `Mail` constructor creates a [personalization object](https://sendgrid.com/d
 The following is the minimum needed code to send an email without the /mail/send Helper ([here](https://github.com/sendgrid/sendgrid-nodejs/blob/master/examples/mail/mail.js#L31) is a full example):
 
 ```javascript
-var sg = require('sendgrid').SendGrid(process.env.SENDGRID_API_KEY)
-var request = sg.emptyRequest()
-request.body = {
-  "personalizations": [
-    {
-      "to": [
-        {
-          "email": "test@example.com"
-        }
-      ],
-      "subject": "Hello World from the SendGrid Node.js Library!"
-    }
-  ],
-  "from": {
-    "email": "test@example.com"
-  },
-  "content": [
-    {
-      "type": "text/plain",
-      "value": "Hello, Email!"
-    }
-  ]
-};
-request.method = 'POST'
-request.path = '/v3/mail/send'
-sg.API(request, function (error, response) {
-  console.log(response.statusCode)
-  console.log(response.body)
-  console.log(response.headers)
-})
+var sg = require('sendgrid')(process.env.SENDGRID_API_KEY);
+var request = sg.emptyRequest({
+  method: 'POST',
+  path: '/v3/mail/send',
+  body: {
+    personalizations: [
+      {
+        to: [
+          {
+            email: 'test@example.com'
+          }
+        ],
+        subject: 'Hello World from the SendGrid Node.js Library!'
+      }
+    ],
+    from: {
+      email: 'test@example.com'
+    },
+    content: [
+      {
+        type: 'text/plain',
+        value: 'Hello, Email!'
+      }
+    ]
+  };
+});
+
+//With promise
+sg.API(request)
+  .then(response => {
+    console.log(response.statusCode);
+    console.log(response.body);
+    console.log(response.headers);
+  })
+  .catch(error => {
+    //error is an instance of SendGridError
+    //The full response is attached to error.response
+    console.log(error.response.statusCode);
+  });
+
+//With callback
+sg.API(request, function(error, response) {
+  if (error) {
+    console.log('Error response received');
+  }
+  console.log(response.statusCode);
+  console.log(response.body);
+  console.log(response.headers);
+});
 ```
 
 ## General v3 Web API Usage
 
 ```javascript
-var sg = require('sendgrid').SendGrid(process.env.SENDGRID_API_KEY)
+var sg = require('sendgrid')(process.env.SENDGRID_API_KEY)
 
 // GET Collection
 var request = sg.emptyRequest()

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The following is the minimum needed code to send an email with the [/mail/send H
   request.method = 'POST'
   request.path = '/v3/mail/send'
   request.body = requestBody
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -122,7 +122,7 @@ request.body = {
 };
 request.method = 'POST'
 request.path = '/v3/mail/send'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -138,7 +138,7 @@ var sg = require('sendgrid').SendGrid(process.env.SENDGRID_API_KEY)
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/api_keys'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)

--- a/README.md
+++ b/README.md
@@ -155,10 +155,29 @@ sg.API(request, function(error, response) {
 var sg = require('sendgrid')(process.env.SENDGRID_API_KEY)
 
 // GET Collection
-var request = sg.emptyRequest()
-request.method = 'GET'
-request.path = '/v3/api_keys'
-sg.API(request, function (error, response) {
+var request = sg.emptyRequest({
+  method: 'GET',
+  path: '/v3/api_keys'
+});
+
+//With promise
+sg.API(request)
+  .then(response => {
+    console.log(response.statusCode)
+    console.log(response.body)
+    console.log(response.headers)
+  })
+  .catch(error => {
+    //error is an instance of SendGridError
+    //The full response is attached to error.response
+    console.log(error.response.statusCode);
+  });
+
+//With callback
+sg.API(request, function(error, response) {
+  if (error) {
+    console.log('Error response received');
+  }
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -73,7 +73,7 @@ To read the error message returned by SendGrid's API:
   content = new helper.Content("text/plain", "Hello, Email!")
   mail = new helper.Mail(from_email, subject, to_email, content)
 
-  var sg = require('sendgrid').SendGrid(process.env.SENDGRID_API_KEY)
+  var sg = require('sendgrid')(process.env.SENDGRID_API_KEY)
   var requestBody = mail.toJSON()
   var request = sg.emptyRequest()
   request.method = 'POST'

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -79,7 +79,7 @@ To read the error message returned by SendGrid's API:
   request.method = 'POST'
   request.path = '/v3/mail/send'
   request.body = requestBody
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)

--- a/USAGE.md
+++ b/USAGE.md
@@ -53,7 +53,7 @@ For more information, please see our [User Guide](http://sendgrid.com/docs/User_
   request.queryParams["limit"] = '1'
   request.method = 'GET'
   request.path = '/v3/access_settings/activity'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -89,7 +89,7 @@ For more information, please see our [User Guide](http://sendgrid.com/docs/User_
 };
   request.method = 'POST'
   request.path = '/v3/access_settings/whitelist'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -110,7 +110,7 @@ For more information, please see our [User Guide](http://sendgrid.com/docs/User_
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/access_settings/whitelist'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -140,7 +140,7 @@ For more information, please see our [User Guide](http://sendgrid.com/docs/User_
 };
   request.method = 'DELETE'
   request.path = '/v3/access_settings/whitelist'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -163,7 +163,7 @@ For more information, please see our [User Guide](http://sendgrid.com/docs/User_
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/access_settings/whitelist/{rule_id}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -186,7 +186,7 @@ For more information, please see our [User Guide](http://sendgrid.com/docs/User_
   var request = sg.emptyRequest()
   request.method = 'DELETE'
   request.path = '/v3/access_settings/whitelist/{rule_id}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -217,7 +217,7 @@ For more information about alerts, please see our [User Guide](https://sendgrid.
 };
   request.method = 'POST'
   request.path = '/v3/alerts'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -240,7 +240,7 @@ For more information about alerts, please see our [User Guide](https://sendgrid.
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/alerts'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -266,7 +266,7 @@ For more information about alerts, please see our [User Guide](https://sendgrid.
 };
   request.method = 'PATCH'
   request.path = '/v3/alerts/{alert_id}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -289,7 +289,7 @@ For more information about alerts, please see our [User Guide](https://sendgrid.
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/alerts/{alert_id}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -312,7 +312,7 @@ For more information about alerts, please see our [User Guide](https://sendgrid.
   var request = sg.emptyRequest()
   request.method = 'DELETE'
   request.path = '/v3/alerts/{alert_id}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -349,7 +349,7 @@ See the [API Key Permissions List](https://sendgrid.com/docs/API_Reference/Web_A
 };
   request.method = 'POST'
   request.path = '/v3/api_keys'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -369,7 +369,7 @@ The API Keys feature allows customers to be able to generate an API Key credenti
   request.queryParams["limit"] = '1'
   request.method = 'GET'
   request.path = '/v3/api_keys'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -399,7 +399,7 @@ The API Keys feature allows customers to be able to generate an API Key credenti
 };
   request.method = 'PUT'
   request.path = '/v3/api_keys/{api_key_id}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -429,7 +429,7 @@ The API Keys feature allows customers to be able to generate an API Key credenti
 };
   request.method = 'PATCH'
   request.path = '/v3/api_keys/{api_key_id}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -448,7 +448,7 @@ If the API Key ID does not exist an HTTP 404 will be returned.
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/api_keys/{api_key_id}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -475,7 +475,7 @@ The API Keys feature allows customers to be able to generate an API Key credenti
   var request = sg.emptyRequest()
   request.method = 'DELETE'
   request.path = '/v3/api_keys/{api_key_id}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -506,7 +506,7 @@ Each user can create up to 25 different suppression groups.
 };
   request.method = 'POST'
   request.path = '/v3/asm/groups'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -530,7 +530,7 @@ Suppression groups, or [unsubscribe groups](https://sendgrid.com/docs/API_Refere
   request.queryParams["id"] = '1'
   request.method = 'GET'
   request.path = '/v3/asm/groups'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -558,7 +558,7 @@ Each user can create up to 25 different suppression groups.
 };
   request.method = 'PATCH'
   request.path = '/v3/asm/groups/{group_id}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -581,7 +581,7 @@ Each user can create up to 25 different suppression groups.
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/asm/groups/{group_id}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -606,7 +606,7 @@ Each user can create up to 25 different suppression groups.
   var request = sg.emptyRequest()
   request.method = 'DELETE'
   request.path = '/v3/asm/groups/{group_id}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -633,7 +633,7 @@ Suppressions are recipient email addresses that are added to [unsubscribe groups
 };
   request.method = 'POST'
   request.path = '/v3/asm/groups/{group_id}/suppressions'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -652,7 +652,7 @@ Suppressions are recipient email addresses that are added to [unsubscribe groups
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/asm/groups/{group_id}/suppressions'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -680,7 +680,7 @@ Suppressions are a list of email addresses that will not receive content sent un
 };
   request.method = 'POST'
   request.path = '/v3/asm/groups/{group_id}/suppressions/search'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -699,7 +699,7 @@ Suppressions are recipient email addresses that are added to [unsubscribe groups
   var request = sg.emptyRequest()
   request.method = 'DELETE'
   request.path = '/v3/asm/groups/{group_id}/suppressions/{email}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -718,7 +718,7 @@ Suppressions are a list of email addresses that will not receive content sent un
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/asm/suppressions'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -743,7 +743,7 @@ A global suppression (or global unsubscribe) is an email address of a recipient 
 };
   request.method = 'POST'
   request.path = '/v3/asm/suppressions/global'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -764,7 +764,7 @@ A global suppression (or global unsubscribe) is an email address of a recipient 
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/asm/suppressions/global/{email}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -783,7 +783,7 @@ A global suppression (or global unsubscribe) is an email address of a recipient 
   var request = sg.emptyRequest()
   request.method = 'DELETE'
   request.path = '/v3/asm/suppressions/global/{email}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -802,7 +802,7 @@ Suppressions are a list of email addresses that will not receive content sent un
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/asm/suppressions/{email}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -832,7 +832,7 @@ Advanced Stats provide a more in-depth view of your email statistics and the act
   request.queryParams["start_date"] = '2016-01-01'
   request.method = 'GET'
   request.path = '/v3/browsers/stats'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -880,7 +880,7 @@ For more information:
 };
   request.method = 'POST'
   request.path = '/v3/campaigns'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -907,7 +907,7 @@ For more information:
   request.queryParams["offset"] = '1'
   request.method = 'GET'
   request.path = '/v3/campaigns'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -937,7 +937,7 @@ For more information:
 };
   request.method = 'PATCH'
   request.path = '/v3/campaigns/{campaign_id}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -960,7 +960,7 @@ For more information:
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/campaigns/{campaign_id}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -983,7 +983,7 @@ For more information:
   var request = sg.emptyRequest()
   request.method = 'DELETE'
   request.path = '/v3/campaigns/{campaign_id}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -1007,7 +1007,7 @@ For more information:
 };
   request.method = 'PATCH'
   request.path = '/v3/campaigns/{campaign_id}/schedules'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -1031,7 +1031,7 @@ For more information:
 };
   request.method = 'POST'
   request.path = '/v3/campaigns/{campaign_id}/schedules'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -1052,7 +1052,7 @@ For more information:
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/campaigns/{campaign_id}/schedules'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -1076,7 +1076,7 @@ For more information:
   var request = sg.emptyRequest()
   request.method = 'DELETE'
   request.path = '/v3/campaigns/{campaign_id}/schedules'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -1099,7 +1099,7 @@ For more information:
   var request = sg.emptyRequest()
   request.method = 'POST'
   request.path = '/v3/campaigns/{campaign_id}/schedules/now'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -1125,7 +1125,7 @@ For more information:
 };
   request.method = 'POST'
   request.path = '/v3/campaigns/{campaign_id}/schedules/test'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -1150,7 +1150,7 @@ Categories can help organize your email analytics by enabling you to tag emails 
   request.queryParams["offset"] = '1'
   request.method = 'GET'
   request.path = '/v3/categories'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -1177,7 +1177,7 @@ Categories allow you to group your emails together according to broad topics tha
   request.queryParams["categories"] = 'test_string'
   request.method = 'GET'
   request.path = '/v3/categories/stats'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -1205,7 +1205,7 @@ Categories allow you to group your emails together according to broad topics tha
   request.queryParams["sort_by_direction"] = 'asc'
   request.method = 'GET'
   request.path = '/v3/categories/stats/sums'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -1232,7 +1232,7 @@ Advanced Stats provide a more in-depth view of your email statistics and the act
   request.queryParams["end_date"] = '2016-04-01'
   request.method = 'GET'
   request.path = '/v3/clients/stats'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -1262,7 +1262,7 @@ Advanced Stats provide a more in-depth view of your email statistics and the act
   request.queryParams["end_date"] = '2016-04-01'
   request.method = 'GET'
   request.path = '/v3/clients/{client_type}/stats'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -1288,7 +1288,7 @@ The contactdb is a database of your contacts for [SendGrid Marketing Campaigns](
 };
   request.method = 'POST'
   request.path = '/v3/contactdb/custom_fields'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -1307,7 +1307,7 @@ The contactdb is a database of your contacts for [SendGrid Marketing Campaigns](
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/contactdb/custom_fields'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -1326,7 +1326,7 @@ The contactdb is a database of your contacts for [SendGrid Marketing Campaigns](
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/contactdb/custom_fields/{custom_field_id}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -1345,7 +1345,7 @@ The contactdb is a database of your contacts for [SendGrid Marketing Campaigns](
   var request = sg.emptyRequest()
   request.method = 'DELETE'
   request.path = '/v3/contactdb/custom_fields/{custom_field_id}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -1367,7 +1367,7 @@ The Contacts API helps you manage your [Marketing Campaigns](https://sendgrid.co
 };
   request.method = 'POST'
   request.path = '/v3/contactdb/lists'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -1386,7 +1386,7 @@ The Contacts API helps you manage your [Marketing Campaigns](https://sendgrid.co
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/contactdb/lists'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -1411,7 +1411,7 @@ The Contacts API helps you manage your [Marketing Campaigns](https://sendgrid.co
 ];
   request.method = 'DELETE'
   request.path = '/v3/contactdb/lists'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -1435,7 +1435,7 @@ The Contacts API helps you manage your [Marketing Campaigns](https://sendgrid.co
   request.queryParams["list_id"] = '1'
   request.method = 'PATCH'
   request.path = '/v3/contactdb/lists/{list_id}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -1455,7 +1455,7 @@ The Contacts API helps you manage your [Marketing Campaigns](https://sendgrid.co
   request.queryParams["list_id"] = '1'
   request.method = 'GET'
   request.path = '/v3/contactdb/lists/{list_id}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -1475,7 +1475,7 @@ The Contacts API helps you manage your [Marketing Campaigns](https://sendgrid.co
   request.queryParams["delete_contacts"] = 'true'
   request.method = 'DELETE'
   request.path = '/v3/contactdb/lists/{list_id}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -1500,7 +1500,7 @@ The Contacts API helps you manage your [Marketing Campaigns](https://sendgrid.co
 ];
   request.method = 'POST'
   request.path = '/v3/contactdb/lists/{list_id}/recipients'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -1522,7 +1522,7 @@ The Contacts API helps you manage your [Marketing Campaigns](https://sendgrid.co
   request.queryParams["list_id"] = '1'
   request.method = 'GET'
   request.path = '/v3/contactdb/lists/{list_id}/recipients'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -1541,7 +1541,7 @@ The Contacts API helps you manage your [Marketing Campaigns](https://sendgrid.co
   var request = sg.emptyRequest()
   request.method = 'POST'
   request.path = '/v3/contactdb/lists/{list_id}/recipients/{recipient_id}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -1562,7 +1562,7 @@ The Contacts API helps you manage your [Marketing Campaigns](https://sendgrid.co
   request.queryParams["list_id"] = '1'
   request.method = 'DELETE'
   request.path = '/v3/contactdb/lists/{list_id}/recipients/{recipient_id}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -1592,7 +1592,7 @@ The contactdb is a database of your contacts for [SendGrid Marketing Campaigns](
 ];
   request.method = 'PATCH'
   request.path = '/v3/contactdb/recipients'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -1627,7 +1627,7 @@ The Contacts API helps you manage your [Marketing Campaigns](https://sendgrid.co
 ];
   request.method = 'POST'
   request.path = '/v3/contactdb/recipients'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -1651,7 +1651,7 @@ The Contacts API helps you manage your [Marketing Campaigns](https://sendgrid.co
   request.queryParams["page_size"] = '1'
   request.method = 'GET'
   request.path = '/v3/contactdb/recipients'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -1676,7 +1676,7 @@ The contactdb is a database of your contacts for [SendGrid Marketing Campaigns](
 ];
   request.method = 'DELETE'
   request.path = '/v3/contactdb/recipients'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -1697,7 +1697,7 @@ The Contacts API helps you manage your [Marketing Campaigns](https://sendgrid.co
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/contactdb/recipients/billable_count'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -1716,7 +1716,7 @@ The contactdb is a database of your contacts for [SendGrid Marketing Campaigns](
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/contactdb/recipients/count'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -1746,7 +1746,7 @@ The contactdb is a database of your contacts for [SendGrid Marketing Campaigns](
   request.queryParams["{field_name}"] = 'test_string'
   request.method = 'GET'
   request.path = '/v3/contactdb/recipients/search'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -1765,7 +1765,7 @@ The Contacts API helps you manage your [Marketing Campaigns](https://sendgrid.co
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/contactdb/recipients/{recipient_id}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -1784,7 +1784,7 @@ The Contacts API helps you manage your [Marketing Campaigns](https://sendgrid.co
   var request = sg.emptyRequest()
   request.method = 'DELETE'
   request.path = '/v3/contactdb/recipients/{recipient_id}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -1805,7 +1805,7 @@ The Contacts API helps you manage your [Marketing Campaigns](https://sendgrid.co
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/contactdb/recipients/{recipient_id}/lists'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -1824,7 +1824,7 @@ The contactdb is a database of your contacts for [SendGrid Marketing Campaigns](
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/contactdb/reserved_fields'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -1887,7 +1887,7 @@ For more information about segments in Marketing Campaigns, please see our [User
 };
   request.method = 'POST'
   request.path = '/v3/contactdb/segments'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -1908,7 +1908,7 @@ For more information about segments in Marketing Campaigns, please see our [User
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/contactdb/segments'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -1942,7 +1942,7 @@ For more information about segments in Marketing Campaigns, please see our [User
   request.queryParams["segment_id"] = 'test_string'
   request.method = 'PATCH'
   request.path = '/v3/contactdb/segments/{segment_id}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -1964,7 +1964,7 @@ For more information about segments in Marketing Campaigns, please see our [User
   request.queryParams["segment_id"] = '1'
   request.method = 'GET'
   request.path = '/v3/contactdb/segments/{segment_id}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -1988,7 +1988,7 @@ For more information about segments in Marketing Campaigns, please see our [User
   request.queryParams["delete_contacts"] = 'true'
   request.method = 'DELETE'
   request.path = '/v3/contactdb/segments/{segment_id}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -2011,7 +2011,7 @@ For more information about segments in Marketing Campaigns, please see our [User
   request.queryParams["page_size"] = '1'
   request.method = 'GET'
   request.path = '/v3/contactdb/segments/{segment_id}/recipients'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -2049,7 +2049,7 @@ Advanced Stats provide a more in-depth view of your email statistics and the act
   request.queryParams["offset"] = '1'
   request.method = 'GET'
   request.path = '/v3/devices/stats'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -2079,7 +2079,7 @@ Advanced Stats provide a more in-depth view of your email statistics and the act
   request.queryParams["start_date"] = '2016-01-01'
   request.method = 'GET'
   request.path = '/v3/geo/stats'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -2108,7 +2108,7 @@ A single IP address or a range of IP addresses may be dedicated to an account in
   request.queryParams["offset"] = '1'
   request.method = 'GET'
   request.path = '/v3/ips'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -2127,7 +2127,7 @@ A single IP address or a range of IP addresses may be dedicated to an account in
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/ips/assigned'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -2155,7 +2155,7 @@ If an IP pool is NOT specified for an email, it will use any IP available, inclu
 };
   request.method = 'POST'
   request.path = '/v3/ips/pools'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -2178,7 +2178,7 @@ If an IP pool is NOT specified for an email, it will use any IP available, inclu
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/ips/pools'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -2204,7 +2204,7 @@ If an IP pool is NOT specified for an email, it will use any IP available, inclu
 };
   request.method = 'PUT'
   request.path = '/v3/ips/pools/{pool_name}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -2227,7 +2227,7 @@ If an IP pool is NOT specified for an email, it will use any IP available, inclu
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/ips/pools/{pool_name}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -2250,7 +2250,7 @@ If an IP pool is NOT specified for an email, it will use any IP available, inclu
   var request = sg.emptyRequest()
   request.method = 'DELETE'
   request.path = '/v3/ips/pools/{pool_name}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -2274,7 +2274,7 @@ A single IP address or a range of IP addresses may be dedicated to an account in
 };
   request.method = 'POST'
   request.path = '/v3/ips/pools/{pool_name}/ips'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -2295,7 +2295,7 @@ A single IP address or a range of IP addresses may be dedicated to an account in
   var request = sg.emptyRequest()
   request.method = 'DELETE'
   request.path = '/v3/ips/pools/{pool_name}/ips/{ip}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -2319,7 +2319,7 @@ For more general information about warming up IPs, please see our [Classroom](ht
 };
   request.method = 'POST'
   request.path = '/v3/ips/warmup'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -2340,7 +2340,7 @@ For more general information about warming up IPs, please see our [Classroom](ht
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/ips/warmup'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -2361,7 +2361,7 @@ For more general information about warming up IPs, please see our [Classroom](ht
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/ips/warmup/{ip_address}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -2382,7 +2382,7 @@ For more general information about warming up IPs, please see our [Classroom](ht
   var request = sg.emptyRequest()
   request.method = 'DELETE'
   request.path = '/v3/ips/warmup/{ip_address}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -2403,7 +2403,7 @@ A single IP address or a range of IP addresses may be dedicated to an account in
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/ips/{ip_address}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -2429,7 +2429,7 @@ More Information:
   var request = sg.emptyRequest()
   request.method = 'POST'
   request.path = '/v3/mail/batch'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -2452,7 +2452,7 @@ More Information:
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/mail/batch/{batch_id}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -2615,7 +2615,7 @@ For more detailed information about how to use the v3 Mail Send endpoint, please
 };
   request.method = 'POST'
   request.path = '/v3/mail/send'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -2639,7 +2639,7 @@ Mail settings allow you to tell SendGrid specific things to do to every email th
   request.queryParams["offset"] = '1'
   request.method = 'GET'
   request.path = '/v3/mail_settings'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -2667,7 +2667,7 @@ Mail settings allow you to tell SendGrid specific things to do to every email th
 };
   request.method = 'PATCH'
   request.path = '/v3/mail_settings/address_whitelist'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -2688,7 +2688,7 @@ Mail settings allow you to tell SendGrid specific things to do to every email th
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/mail_settings/address_whitelist'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -2713,7 +2713,7 @@ Mail settings allow you to tell SendGrid specific things to do to every email th
 };
   request.method = 'PATCH'
   request.path = '/v3/mail_settings/bcc'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -2734,7 +2734,7 @@ Mail settings allow you to tell SendGrid specific things to do to every email th
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/mail_settings/bcc'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -2760,7 +2760,7 @@ Mail settings allow you to tell SendGrid specific things to do to every email th
 };
   request.method = 'PATCH'
   request.path = '/v3/mail_settings/bounce_purge'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -2781,7 +2781,7 @@ Mail settings allow you to tell SendGrid specific things to do to every email th
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/mail_settings/bounce_purge'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -2807,7 +2807,7 @@ Mail settings allow you to tell SendGrid specific things to do to every email th
 };
   request.method = 'PATCH'
   request.path = '/v3/mail_settings/footer'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -2828,7 +2828,7 @@ Mail settings allow you to tell SendGrid specific things to do to every email th
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/mail_settings/footer'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -2853,7 +2853,7 @@ Mail settings allow you to tell SendGrid specific things to do to every email th
 };
   request.method = 'PATCH'
   request.path = '/v3/mail_settings/forward_bounce'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -2874,7 +2874,7 @@ Mail settings allow you to tell SendGrid specific things to do to every email th
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/mail_settings/forward_bounce'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -2899,7 +2899,7 @@ Mail settings allow you to tell SendGrid specific things to do to every email th
 };
   request.method = 'PATCH'
   request.path = '/v3/mail_settings/forward_spam'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -2920,7 +2920,7 @@ Mail settings allow you to tell SendGrid specific things to do to every email th
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/mail_settings/forward_spam'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -2944,7 +2944,7 @@ Mail settings allow you to tell SendGrid specific things to do to every email th
 };
   request.method = 'PATCH'
   request.path = '/v3/mail_settings/plain_content'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -2965,7 +2965,7 @@ Mail settings allow you to tell SendGrid specific things to do to every email th
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/mail_settings/plain_content'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -2991,7 +2991,7 @@ Mail settings allow you to tell SendGrid specific things to do to every email th
 };
   request.method = 'PATCH'
   request.path = '/v3/mail_settings/spam_check'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -3012,7 +3012,7 @@ Mail settings allow you to tell SendGrid specific things to do to every email th
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/mail_settings/spam_check'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -3039,7 +3039,7 @@ Mail settings allow you to tell SendGrid specific things to do to every email th
 };
   request.method = 'PATCH'
   request.path = '/v3/mail_settings/template'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -3062,7 +3062,7 @@ Mail settings allow you to tell SendGrid specific things to do to every email th
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/mail_settings/template'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -3092,7 +3092,7 @@ Advanced Stats provide a more in-depth view of your email statistics and the act
   request.queryParams["start_date"] = '2016-01-01'
   request.method = 'GET'
   request.path = '/v3/mailbox_providers/stats'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -3116,7 +3116,7 @@ Our partner settings allow you to integrate your SendGrid account with our partn
   request.queryParams["offset"] = '1'
   request.method = 'GET'
   request.path = '/v3/partner_settings'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -3142,7 +3142,7 @@ By integrating with New Relic, you can send your SendGrid email statistics to yo
 };
   request.method = 'PATCH'
   request.path = '/v3/partner_settings/new_relic'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -3163,7 +3163,7 @@ By integrating with New Relic, you can send your SendGrid email statistics to yo
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/partner_settings/new_relic'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -3185,7 +3185,7 @@ API Keys can be used to authenticate the use of [SendGrids v3 Web API](https://s
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/scopes'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -3212,7 +3212,7 @@ Parent accounts will see aggregated stats for their account and all subuser acco
   request.queryParams["offset"] = '1'
   request.method = 'GET'
   request.path = '/v3/stats'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -3246,7 +3246,7 @@ For more information about Subusers:
 };
   request.method = 'POST'
   request.path = '/v3/subusers'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -3271,7 +3271,7 @@ For more information about Subusers:
   request.queryParams["offset"] = '1'
   request.method = 'GET'
   request.path = '/v3/subusers'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -3291,7 +3291,7 @@ This endpoint allows you to request the reputations for your subusers.
   request.queryParams["usernames"] = 'test_string'
   request.method = 'GET'
   request.path = '/v3/subusers/reputations'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -3320,7 +3320,7 @@ For more information, see our [User Guide](https://sendgrid.com/docs/User_Guide/
   request.queryParams["subusers"] = 'test_string'
   request.method = 'GET'
   request.path = '/v3/subusers/stats'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -3350,7 +3350,7 @@ For more information, see our [User Guide](https://sendgrid.com/docs/User_Guide/
   request.queryParams["sort_by_direction"] = 'asc'
   request.method = 'GET'
   request.path = '/v3/subusers/stats/monthly'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -3379,7 +3379,7 @@ For more information, see our [User Guide](https://sendgrid.com/docs/User_Guide/
   request.queryParams["sort_by_direction"] = 'asc'
   request.method = 'GET'
   request.path = '/v3/subusers/stats/sums'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -3404,7 +3404,7 @@ For more information about Subusers:
 };
   request.method = 'PATCH'
   request.path = '/v3/subusers/{subuser_name}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -3426,7 +3426,7 @@ For more information about Subusers:
   var request = sg.emptyRequest()
   request.method = 'DELETE'
   request.path = '/v3/subusers/{subuser_name}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -3451,7 +3451,7 @@ More information:
 ];
   request.method = 'PUT'
   request.path = '/v3/subusers/{subuser_name}/ips'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -3472,7 +3472,7 @@ Subuser monitor settings allow you to receive a sample of an outgoing message by
 };
   request.method = 'PUT'
   request.path = '/v3/subusers/{subuser_name}/monitor'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -3493,7 +3493,7 @@ Subuser monitor settings allow you to receive a sample of an outgoing message by
 };
   request.method = 'POST'
   request.path = '/v3/subusers/{subuser_name}/monitor'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -3510,7 +3510,7 @@ Subuser monitor settings allow you to receive a sample of an outgoing message by
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/subusers/{subuser_name}/monitor'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -3527,7 +3527,7 @@ Subuser monitor settings allow you to receive a sample of an outgoing message by
   var request = sg.emptyRequest()
   request.method = 'DELETE'
   request.path = '/v3/subusers/{subuser_name}/monitor'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -3556,7 +3556,7 @@ For more information, see our [User Guide](https://sendgrid.com/docs/User_Guide/
   request.queryParams["offset"] = '1'
   request.method = 'GET'
   request.path = '/v3/subusers/{subuser_name}/stats/monthly'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -3584,7 +3584,7 @@ For more information, please see our [User Guide](https://sendgrid.com/docs/User
   request.queryParams["offset"] = '1'
   request.method = 'GET'
   request.path = '/v3/suppression/blocks'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -3617,7 +3617,7 @@ For more information, please see our [User Guide](https://sendgrid.com/docs/User
 };
   request.method = 'DELETE'
   request.path = '/v3/suppression/blocks'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -3638,7 +3638,7 @@ For more information, please see our [User Guide](https://sendgrid.com/docs/User
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/suppression/blocks/{email}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -3659,7 +3659,7 @@ For more information, please see our [User Guide](https://sendgrid.com/docs/User
   var request = sg.emptyRequest()
   request.method = 'DELETE'
   request.path = '/v3/suppression/blocks/{email}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -3685,7 +3685,7 @@ For more information see:
   request.queryParams["end_time"] = '1'
   request.method = 'GET'
   request.path = '/v3/suppression/bounces'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -3719,7 +3719,7 @@ Note: the `delete_all` and `emails` parameters should be used independently of e
 };
   request.method = 'DELETE'
   request.path = '/v3/suppression/bounces'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -3744,7 +3744,7 @@ For more information see:
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/suppression/bounces/{email}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -3770,7 +3770,7 @@ For more information see:
   request.queryParams["email_address"] = 'example@example.com'
   request.method = 'DELETE'
   request.path = '/v3/suppression/bounces/{email}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -3797,7 +3797,7 @@ For more information, please see our [User Guide](https://sendgrid.com/docs/User
   request.queryParams["offset"] = '1'
   request.method = 'GET'
   request.path = '/v3/suppression/invalid_emails'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -3832,7 +3832,7 @@ For more information, please see our [User Guide](https://sendgrid.com/docs/User
 };
   request.method = 'DELETE'
   request.path = '/v3/suppression/invalid_emails'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -3855,7 +3855,7 @@ For more information, please see our [User Guide](https://sendgrid.com/docs/User
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/suppression/invalid_emails/{email}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -3878,7 +3878,7 @@ For more information, please see our [User Guide](https://sendgrid.com/docs/User
   var request = sg.emptyRequest()
   request.method = 'DELETE'
   request.path = '/v3/suppression/invalid_emails/{email}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -3899,7 +3899,7 @@ For more information, please see our [User Guide](https://sendgrid.com/docs/User
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/suppression/spam_report/{email}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -3920,7 +3920,7 @@ For more information, please see our [User Guide](https://sendgrid.com/docs/User
   var request = sg.emptyRequest()
   request.method = 'DELETE'
   request.path = '/v3/suppression/spam_report/{email}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -3945,7 +3945,7 @@ For more information, please see our [User Guide](https://sendgrid.com/docs/User
   request.queryParams["offset"] = '1'
   request.method = 'GET'
   request.path = '/v3/suppression/spam_reports'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -3978,7 +3978,7 @@ For more information, please see our [User Guide](https://sendgrid.com/docs/User
 };
   request.method = 'DELETE'
   request.path = '/v3/suppression/spam_reports'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -4001,7 +4001,7 @@ A global suppression (or global unsubscribe) is an email address of a recipient 
   request.queryParams["offset"] = '1'
   request.method = 'GET'
   request.path = '/v3/suppression/unsubscribes'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -4028,7 +4028,7 @@ Transactional templates are templates created specifically for transactional ema
 };
   request.method = 'POST'
   request.path = '/v3/templates'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -4049,7 +4049,7 @@ Transactional templates are templates created specifically for transactional ema
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/templates'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -4074,7 +4074,7 @@ Transactional templates are templates created specifically for transactional ema
 };
   request.method = 'PATCH'
   request.path = '/v3/templates/{template_id}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -4096,7 +4096,7 @@ Transactional templates are templates created specifically for transactional ema
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/templates/{template_id}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -4118,7 +4118,7 @@ Transactional templates are templates created specifically for transactional ema
   var request = sg.emptyRequest()
   request.method = 'DELETE'
   request.path = '/v3/templates/{template_id}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -4148,7 +4148,7 @@ For more information about transactional templates, please see our [User Guide](
 };
   request.method = 'POST'
   request.path = '/v3/templates/{template_id}/versions'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -4182,7 +4182,7 @@ For more information about transactional templates, please see our [User Guide](
 };
   request.method = 'PATCH'
   request.path = '/v3/templates/{template_id}/versions/{version_id}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -4209,7 +4209,7 @@ For more information about transactional templates, please see our [User Guide](
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/templates/{template_id}/versions/{version_id}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -4236,7 +4236,7 @@ For more information about transactional templates, please see our [User Guide](
   var request = sg.emptyRequest()
   request.method = 'DELETE'
   request.path = '/v3/templates/{template_id}/versions/{version_id}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -4264,7 +4264,7 @@ For more information about transactional templates, please see our [User Guide](
   var request = sg.emptyRequest()
   request.method = 'POST'
   request.path = '/v3/templates/{template_id}/versions/{version_id}/activate'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -4290,7 +4290,7 @@ For more information about tracking, please see our [User Guide](https://sendgri
   request.queryParams["offset"] = '1'
   request.method = 'GET'
   request.path = '/v3/tracking_settings'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -4314,7 +4314,7 @@ For more information about tracking, please see our [User Guide](https://sendgri
 };
   request.method = 'PATCH'
   request.path = '/v3/tracking_settings/click'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -4335,7 +4335,7 @@ For more information about tracking, please see our [User Guide](https://sendgri
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/tracking_settings/click'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -4368,7 +4368,7 @@ For more information about tracking, please see our [User Guide](https://sendgri
 };
   request.method = 'PATCH'
   request.path = '/v3/tracking_settings/google_analytics'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -4393,7 +4393,7 @@ For more information about tracking, please see our [User Guide](https://sendgri
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/tracking_settings/google_analytics'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -4419,7 +4419,7 @@ For more information about tracking, please see our [User Guide](https://sendgri
 };
   request.method = 'PATCH'
   request.path = '/v3/tracking_settings/open'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -4442,7 +4442,7 @@ For more information about tracking, please see our [User Guide](https://sendgri
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/tracking_settings/open'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -4473,7 +4473,7 @@ For more information about tracking, please see our [User Guide](https://sendgri
 };
   request.method = 'PATCH'
   request.path = '/v3/tracking_settings/subscription'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -4496,7 +4496,7 @@ For more information about tracking, please see our [User Guide](https://sendgri
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/tracking_settings/subscription'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -4524,7 +4524,7 @@ For more information about your user profile:
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/user/account'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -4543,7 +4543,7 @@ Your monthly credit allotment limits the number of emails you may send before in
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/user/credits'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -4569,7 +4569,7 @@ For more information about your user profile:
 };
   request.method = 'PUT'
   request.path = '/v3/user/email'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -4592,7 +4592,7 @@ For more information about your user profile:
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/user/email'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -4619,7 +4619,7 @@ For more information about your user profile:
 };
   request.method = 'PUT'
   request.path = '/v3/user/password'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -4649,7 +4649,7 @@ It should be noted that any one or more of the parameters can be updated via the
 };
   request.method = 'PATCH'
   request.path = '/v3/user/profile'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -4670,7 +4670,7 @@ For more information about your user profile:
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/user/profile'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -4696,7 +4696,7 @@ The Cancel Scheduled Sends feature allows the customer to cancel a scheduled sen
 };
   request.method = 'POST'
   request.path = '/v3/user/scheduled_sends'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -4715,7 +4715,7 @@ The Cancel Scheduled Sends feature allows the customer to cancel a scheduled sen
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/user/scheduled_sends'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -4737,7 +4737,7 @@ The Cancel Scheduled Sends feature allows the customer to cancel a scheduled sen
 };
   request.method = 'PATCH'
   request.path = '/v3/user/scheduled_sends/{batch_id}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -4756,7 +4756,7 @@ The Cancel Scheduled Sends feature allows the customer to cancel a scheduled sen
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/user/scheduled_sends/{batch_id}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -4775,7 +4775,7 @@ The Cancel Scheduled Sends feature allows the customer to cancel a scheduled sen
   var request = sg.emptyRequest()
   request.method = 'DELETE'
   request.path = '/v3/user/scheduled_sends/{batch_id}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -4800,7 +4800,7 @@ The Enforced TLS settings specify whether or not the recipient is required to su
 };
   request.method = 'PATCH'
   request.path = '/v3/user/settings/enforced_tls'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -4821,7 +4821,7 @@ The Enforced TLS settings specify whether or not the recipient is required to su
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/user/settings/enforced_tls'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -4847,7 +4847,7 @@ For more information about your user profile:
 };
   request.method = 'PUT'
   request.path = '/v3/user/username'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -4870,7 +4870,7 @@ For more information about your user profile:
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/user/username'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -4908,7 +4908,7 @@ Common uses of this data are to remove unsubscribes, react to spam reports, dete
 };
   request.method = 'PATCH'
   request.path = '/v3/user/webhooks/event/settings'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -4931,7 +4931,7 @@ Common uses of this data are to remove unsubscribes, react to spam reports, dete
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/user/webhooks/event/settings'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -4955,7 +4955,7 @@ Common uses of this data are to remove unsubscribes, react to spam reports, dete
 };
   request.method = 'POST'
   request.path = '/v3/user/webhooks/event/test'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -4980,7 +4980,7 @@ The inbound parse webhook allows you to have incoming emails parsed, extracting 
 };
   request.method = 'POST'
   request.path = '/v3/user/webhooks/parse/settings'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -4999,7 +4999,7 @@ The inbound parse webhook allows you to have incoming emails parsed, extracting 
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/user/webhooks/parse/settings'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -5023,7 +5023,7 @@ The inbound parse webhook allows you to have incoming emails parsed, extracting 
 };
   request.method = 'PATCH'
   request.path = '/v3/user/webhooks/parse/settings/{hostname}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -5042,7 +5042,7 @@ The inbound parse webhook allows you to have incoming emails parsed, extracting 
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/user/webhooks/parse/settings/{hostname}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -5061,7 +5061,7 @@ The inbound parse webhook allows you to have incoming emails parsed, extracting 
   var request = sg.emptyRequest()
   request.method = 'DELETE'
   request.path = '/v3/user/webhooks/parse/settings/{hostname}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -5087,7 +5087,7 @@ There are a number of pre-made integrations for the SendGrid Parse Webhook which
   request.queryParams["offset"] = 'test_string'
   request.method = 'GET'
   request.path = '/v3/user/webhooks/parse/stats'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -5127,7 +5127,7 @@ For more information on whitelabeling, please see our [User Guide](https://sendg
 };
   request.method = 'POST'
   request.path = '/v3/whitelabel/domains'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -5154,7 +5154,7 @@ For more information on whitelabeling, please see our [User Guide](https://sendg
   request.queryParams["offset"] = '1'
   request.method = 'GET'
   request.path = '/v3/whitelabel/domains'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -5180,7 +5180,7 @@ For more information on whitelabeling, please see our [User Guide](https://sendg
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/whitelabel/domains/default'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -5208,7 +5208,7 @@ For more information on whitelabeling, please see our [User Guide](https://sendg
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/whitelabel/domains/subuser'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -5236,7 +5236,7 @@ For more information on whitelabeling, please see our [User Guide](https://sendg
   var request = sg.emptyRequest()
   request.method = 'DELETE'
   request.path = '/v3/whitelabel/domains/subuser'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -5261,7 +5261,7 @@ For more information on whitelabeling, please see our [User Guide](https://sendg
 };
   request.method = 'PATCH'
   request.path = '/v3/whitelabel/domains/{domain_id}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -5283,7 +5283,7 @@ For more information on whitelabeling, please see our [User Guide](https://sendg
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/whitelabel/domains/{domain_id}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -5304,7 +5304,7 @@ For more information on whitelabeling, please see our [User Guide](https://sendg
   var request = sg.emptyRequest()
   request.method = 'DELETE'
   request.path = '/v3/whitelabel/domains/{domain_id}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -5335,7 +5335,7 @@ For more information on whitelabeling, please see our [User Guide](https://sendg
 };
   request.method = 'POST'
   request.path = '/v3/whitelabel/domains/{domain_id}/subuser'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -5364,7 +5364,7 @@ For more information on whitelabeling, please see our [User Guide](https://sendg
 };
   request.method = 'POST'
   request.path = '/v3/whitelabel/domains/{id}/ips'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -5391,7 +5391,7 @@ For more information on whitelabeling, please see our [User Guide](https://sendg
   var request = sg.emptyRequest()
   request.method = 'DELETE'
   request.path = '/v3/whitelabel/domains/{id}/ips/{ip}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -5417,7 +5417,7 @@ For more information on whitelabeling, please see our [User Guide](https://sendg
   var request = sg.emptyRequest()
   request.method = 'POST'
   request.path = '/v3/whitelabel/domains/{id}/validate'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -5445,7 +5445,7 @@ For more information, please see our [User Guide](https://sendgrid.com/docs/API_
 };
   request.method = 'POST'
   request.path = '/v3/whitelabel/ips'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -5471,7 +5471,7 @@ For more information, please see our [User Guide](https://sendgrid.com/docs/API_
   request.queryParams["offset"] = '1'
   request.method = 'GET'
   request.path = '/v3/whitelabel/ips'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -5492,7 +5492,7 @@ For more information, please see our [User Guide](https://sendgrid.com/docs/API_
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/whitelabel/ips/{id}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -5513,7 +5513,7 @@ For more information, please see our [User Guide](https://sendgrid.com/docs/API_
   var request = sg.emptyRequest()
   request.method = 'DELETE'
   request.path = '/v3/whitelabel/ips/{id}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -5534,7 +5534,7 @@ For more information, please see our [User Guide](https://sendgrid.com/docs/API_
   var request = sg.emptyRequest()
   request.method = 'POST'
   request.path = '/v3/whitelabel/ips/{id}/validate'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -5562,7 +5562,7 @@ For more information, please see our [User Guide](https://sendgrid.com/docs/API_
   request.queryParams["offset"] = '1'
   request.method = 'POST'
   request.path = '/v3/whitelabel/links'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -5584,7 +5584,7 @@ For more information, please see our [User Guide](https://sendgrid.com/docs/API_
   request.queryParams["limit"] = '1'
   request.method = 'GET'
   request.path = '/v3/whitelabel/links'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -5613,7 +5613,7 @@ For more information, please see our [User Guide](https://sendgrid.com/docs/API_
   request.queryParams["domain"] = 'test_string'
   request.method = 'GET'
   request.path = '/v3/whitelabel/links/default'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -5639,7 +5639,7 @@ For more information, please see our [User Guide](https://sendgrid.com/docs/API_
   request.queryParams["username"] = 'test_string'
   request.method = 'GET'
   request.path = '/v3/whitelabel/links/subuser'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -5665,7 +5665,7 @@ For more information, please see our [User Guide](https://sendgrid.com/docs/API_
   request.queryParams["username"] = 'test_string'
   request.method = 'DELETE'
   request.path = '/v3/whitelabel/links/subuser'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -5689,7 +5689,7 @@ For more information, please see our [User Guide](https://sendgrid.com/docs/API_
 };
   request.method = 'PATCH'
   request.path = '/v3/whitelabel/links/{id}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -5710,7 +5710,7 @@ For more information, please see our [User Guide](https://sendgrid.com/docs/API_
   var request = sg.emptyRequest()
   request.method = 'GET'
   request.path = '/v3/whitelabel/links/{id}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -5731,7 +5731,7 @@ For more information, please see our [User Guide](https://sendgrid.com/docs/API_
   var request = sg.emptyRequest()
   request.method = 'DELETE'
   request.path = '/v3/whitelabel/links/{id}'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -5752,7 +5752,7 @@ For more information, please see our [User Guide](https://sendgrid.com/docs/API_
   var request = sg.emptyRequest()
   request.method = 'POST'
   request.path = '/v3/whitelabel/links/{id}/validate'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)
@@ -5780,7 +5780,7 @@ For more information, please see our [User Guide](https://sendgrid.com/docs/API_
 };
   request.method = 'POST'
   request.path = '/v3/whitelabel/links/{link_id}/subuser'
-  sg.API(request, function (response) {
+  sg.API(request, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)

--- a/USAGE.md
+++ b/USAGE.md
@@ -3,7 +3,7 @@ This documentation is based on our [OAI specification](https://github.com/sendgr
 # INITIALIZATION
 
 ```javascript
-var sg = require('sendgrid').SendGrid(process.env.SENDGRID_API_KEY)
+var sg = require('sendgrid')(process.env.SENDGRID_API_KEY)
 ```
 
 # Table of Contents

--- a/examples/accesssettings/accesssettings.js
+++ b/examples/accesssettings/accesssettings.js
@@ -10,7 +10,7 @@ request.queryParams["limit"] = '1'
  
 request.method = 'GET'
 request.path = '/v3/access_settings/activity'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -37,7 +37,7 @@ request.body = {
 };
 request.method = 'POST'
 request.path = '/v3/access_settings/whitelist'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -51,7 +51,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/access_settings/whitelist'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -72,7 +72,7 @@ request.body = {
 };
 request.method = 'DELETE'
 request.path = '/v3/access_settings/whitelist'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -86,7 +86,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/access_settings/whitelist/{rule_id}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -100,7 +100,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'DELETE'
 request.path = '/v3/access_settings/whitelist/{rule_id}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)

--- a/examples/accesssettings/accesssettings.js
+++ b/examples/accesssettings/accesssettings.js
@@ -1,4 +1,4 @@
-var sg = require('sendgrid').SendGrid(process.env.SENDGRID_API_KEY)
+var sg = require('sendgrid')(process.env.SENDGRID_API_KEY)
 
 ///////////////////////////////////////////////////
 // Retrieve all recent access attempts
@@ -7,7 +7,7 @@ var sg = require('sendgrid').SendGrid(process.env.SENDGRID_API_KEY)
 
 var request = sg.emptyRequest()
 request.queryParams["limit"] = '1'
- 
+
 request.method = 'GET'
 request.path = '/v3/access_settings/activity'
 sg.API(request, function (error, response) {
@@ -26,10 +26,10 @@ request.body = {
   "ips": [
     {
       "ip": "192.168.1.1"
-    }, 
+    },
     {
       "ip": "192.*.*.*"
-    }, 
+    },
     {
       "ip": "192.168.1.3/32"
     }
@@ -65,8 +65,8 @@ sg.API(request, function (error, response) {
 var request = sg.emptyRequest()
 request.body = {
   "ids": [
-    1, 
-    2, 
+    1,
+    2,
     3
   ]
 };
@@ -105,4 +105,3 @@ sg.API(request, function (error, response) {
   console.log(response.body)
   console.log(response.headers)
 })
-

--- a/examples/alerts/alerts.js
+++ b/examples/alerts/alerts.js
@@ -1,4 +1,4 @@
-var sg = require('sendgrid').SendGrid(process.env.SENDGRID_API_KEY)
+var sg = require('sendgrid')(process.env.SENDGRID_API_KEY)
 
 ///////////////////////////////////////////////////
 // Create a new Alert

--- a/examples/alerts/alerts.js
+++ b/examples/alerts/alerts.js
@@ -13,7 +13,7 @@ request.body = {
 };
 request.method = 'POST'
 request.path = '/v3/alerts'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -27,7 +27,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/alerts'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -44,7 +44,7 @@ request.body = {
 };
 request.method = 'PATCH'
 request.path = '/v3/alerts/{alert_id}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -58,7 +58,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/alerts/{alert_id}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -72,7 +72,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'DELETE'
 request.path = '/v3/alerts/{alert_id}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)

--- a/examples/apikeys/apikeys.js
+++ b/examples/apikeys/apikeys.js
@@ -1,4 +1,4 @@
-var sg = require('sendgrid').SendGrid(process.env.SENDGRID_API_KEY)
+var sg = require('sendgrid')(process.env.SENDGRID_API_KEY)
 
 ///////////////////////////////////////////////////
 // Create API keys

--- a/examples/apikeys/apikeys.js
+++ b/examples/apikeys/apikeys.js
@@ -17,7 +17,7 @@ request.body = {
 };
 request.method = 'POST'
 request.path = '/v3/api_keys'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -33,7 +33,7 @@ request.queryParams["limit"] = '1'
  
 request.method = 'GET'
 request.path = '/v3/api_keys'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -54,7 +54,7 @@ request.body = {
 };
 request.method = 'PUT'
 request.path = '/v3/api_keys/{api_key_id}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -71,7 +71,7 @@ request.body = {
 };
 request.method = 'PATCH'
 request.path = '/v3/api_keys/{api_key_id}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -85,7 +85,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/api_keys/{api_key_id}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -99,7 +99,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'DELETE'
 request.path = '/v3/api_keys/{api_key_id}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)

--- a/examples/asm/asm.js
+++ b/examples/asm/asm.js
@@ -13,7 +13,7 @@ request.body = {
 };
 request.method = 'POST'
 request.path = '/v3/asm/groups'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -29,7 +29,7 @@ request.queryParams["id"] = '1'
  
 request.method = 'GET'
 request.path = '/v3/asm/groups'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -48,7 +48,7 @@ request.body = {
 };
 request.method = 'PATCH'
 request.path = '/v3/asm/groups/{group_id}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -62,7 +62,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/asm/groups/{group_id}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -76,7 +76,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'DELETE'
 request.path = '/v3/asm/groups/{group_id}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -96,7 +96,7 @@ request.body = {
 };
 request.method = 'POST'
 request.path = '/v3/asm/groups/{group_id}/suppressions'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -110,7 +110,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/asm/groups/{group_id}/suppressions'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -131,7 +131,7 @@ request.body = {
 };
 request.method = 'POST'
 request.path = '/v3/asm/groups/{group_id}/suppressions/search'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -145,7 +145,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'DELETE'
 request.path = '/v3/asm/groups/{group_id}/suppressions/{email}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -159,7 +159,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/asm/suppressions'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -179,7 +179,7 @@ request.body = {
 };
 request.method = 'POST'
 request.path = '/v3/asm/suppressions/global'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -193,7 +193,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/asm/suppressions/global/{email}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -207,7 +207,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'DELETE'
 request.path = '/v3/asm/suppressions/global/{email}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -221,7 +221,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/asm/suppressions/{email}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)

--- a/examples/asm/asm.js
+++ b/examples/asm/asm.js
@@ -1,4 +1,4 @@
-var sg = require('sendgrid').SendGrid(process.env.SENDGRID_API_KEY)
+var sg = require('sendgrid')(process.env.SENDGRID_API_KEY)
 
 ///////////////////////////////////////////////////
 // Create a new suppression group

--- a/examples/browsers/browsers.js
+++ b/examples/browsers/browsers.js
@@ -1,4 +1,4 @@
-var sg = require('sendgrid').SendGrid(process.env.SENDGRID_API_KEY)
+var sg = require('sendgrid')(process.env.SENDGRID_API_KEY)
 
 ///////////////////////////////////////////////////
 // Retrieve email statistics by browser. 

--- a/examples/browsers/browsers.js
+++ b/examples/browsers/browsers.js
@@ -15,7 +15,7 @@ request.queryParams["end_date"] = '2016-04-01'
  
 request.method = 'GET'
 request.path = '/v3/browsers/stats'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)

--- a/examples/campaigns/campaigns.js
+++ b/examples/campaigns/campaigns.js
@@ -1,4 +1,4 @@
-var sg = require('sendgrid').SendGrid(process.env.SENDGRID_API_KEY)
+var sg = require('sendgrid')(process.env.SENDGRID_API_KEY)
 
 ///////////////////////////////////////////////////
 // Create a Campaign

--- a/examples/campaigns/campaigns.js
+++ b/examples/campaigns/campaigns.js
@@ -28,7 +28,7 @@ request.body = {
 };
 request.method = 'POST'
 request.path = '/v3/campaigns'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -45,7 +45,7 @@ request.queryParams["limit"] = '1'
  
 request.method = 'GET'
 request.path = '/v3/campaigns'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -68,7 +68,7 @@ request.body = {
 };
 request.method = 'PATCH'
 request.path = '/v3/campaigns/{campaign_id}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -82,7 +82,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/campaigns/{campaign_id}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -96,7 +96,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'DELETE'
 request.path = '/v3/campaigns/{campaign_id}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -113,7 +113,7 @@ request.body = {
 };
 request.method = 'PATCH'
 request.path = '/v3/campaigns/{campaign_id}/schedules'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -130,7 +130,7 @@ request.body = {
 };
 request.method = 'POST'
 request.path = '/v3/campaigns/{campaign_id}/schedules'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -144,7 +144,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/campaigns/{campaign_id}/schedules'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -158,7 +158,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'DELETE'
 request.path = '/v3/campaigns/{campaign_id}/schedules'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -172,7 +172,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'POST'
 request.path = '/v3/campaigns/{campaign_id}/schedules/now'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -189,7 +189,7 @@ request.body = {
 };
 request.method = 'POST'
 request.path = '/v3/campaigns/{campaign_id}/schedules/test'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)

--- a/examples/categories/categories.js
+++ b/examples/categories/categories.js
@@ -1,4 +1,4 @@
-var sg = require('sendgrid').SendGrid(process.env.SENDGRID_API_KEY)
+var sg = require('sendgrid')(process.env.SENDGRID_API_KEY)
 
 ///////////////////////////////////////////////////
 // Retrieve all categories

--- a/examples/categories/categories.js
+++ b/examples/categories/categories.js
@@ -12,7 +12,7 @@ request.queryParams["category"] = 'test_string'
  
 request.method = 'GET'
 request.path = '/v3/categories'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -33,7 +33,7 @@ request.queryParams["end_date"] = '2016-04-01'
  
 request.method = 'GET'
 request.path = '/v3/categories/stats'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -55,7 +55,7 @@ request.queryParams["end_date"] = '2016-04-01'
  
 request.method = 'GET'
 request.path = '/v3/categories/stats/sums'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)

--- a/examples/clients/clients.js
+++ b/examples/clients/clients.js
@@ -1,4 +1,4 @@
-var sg = require('sendgrid').SendGrid(process.env.SENDGRID_API_KEY)
+var sg = require('sendgrid')(process.env.SENDGRID_API_KEY)
 
 ///////////////////////////////////////////////////
 // Retrieve email statistics by client type.

--- a/examples/clients/clients.js
+++ b/examples/clients/clients.js
@@ -12,7 +12,7 @@ request.queryParams["aggregated_by"] = 'day'
  
 request.method = 'GET'
 request.path = '/v3/clients/stats'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -30,7 +30,7 @@ request.queryParams["aggregated_by"] = 'day'
  
 request.method = 'GET'
 request.path = '/v3/clients/{client_type}/stats'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)

--- a/examples/contactdb/contactdb.js
+++ b/examples/contactdb/contactdb.js
@@ -12,7 +12,7 @@ request.body = {
 };
 request.method = 'POST'
 request.path = '/v3/contactdb/custom_fields'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -26,7 +26,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/contactdb/custom_fields'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -40,7 +40,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/contactdb/custom_fields/{custom_field_id}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -54,7 +54,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'DELETE'
 request.path = '/v3/contactdb/custom_fields/{custom_field_id}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -71,7 +71,7 @@ request.body = {
 };
 request.method = 'POST'
 request.path = '/v3/contactdb/lists'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -85,7 +85,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/contactdb/lists'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -105,7 +105,7 @@ request.body = [
 ];
 request.method = 'DELETE'
 request.path = '/v3/contactdb/lists'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -124,7 +124,7 @@ request.queryParams["list_id"] = '1'
  
 request.method = 'PATCH'
 request.path = '/v3/contactdb/lists/{list_id}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -140,7 +140,7 @@ request.queryParams["list_id"] = '1'
  
 request.method = 'GET'
 request.path = '/v3/contactdb/lists/{list_id}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -156,7 +156,7 @@ request.queryParams["delete_contacts"] = 'true'
  
 request.method = 'DELETE'
 request.path = '/v3/contactdb/lists/{list_id}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -174,7 +174,7 @@ request.body = [
 ];
 request.method = 'POST'
 request.path = '/v3/contactdb/lists/{list_id}/recipients'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -192,7 +192,7 @@ request.queryParams["page"] = '1'
  
 request.method = 'GET'
 request.path = '/v3/contactdb/lists/{list_id}/recipients'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -206,7 +206,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'POST'
 request.path = '/v3/contactdb/lists/{list_id}/recipients/{recipient_id}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -223,7 +223,7 @@ request.queryParams["recipient_id"] = '1'
  
 request.method = 'DELETE'
 request.path = '/v3/contactdb/lists/{list_id}/recipients/{recipient_id}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -244,7 +244,7 @@ request.body = [
 ];
 request.method = 'PATCH'
 request.path = '/v3/contactdb/recipients'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -272,7 +272,7 @@ request.body = [
 ];
 request.method = 'POST'
 request.path = '/v3/contactdb/recipients'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -289,7 +289,7 @@ request.queryParams["page"] = '1'
  
 request.method = 'GET'
 request.path = '/v3/contactdb/recipients'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -307,7 +307,7 @@ request.body = [
 ];
 request.method = 'DELETE'
 request.path = '/v3/contactdb/recipients'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -321,7 +321,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/contactdb/recipients/billable_count'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -335,7 +335,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/contactdb/recipients/count'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -351,7 +351,7 @@ request.queryParams["{field_name}"] = 'test_string'
  
 request.method = 'GET'
 request.path = '/v3/contactdb/recipients/search'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -365,7 +365,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/contactdb/recipients/{recipient_id}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -379,7 +379,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'DELETE'
 request.path = '/v3/contactdb/recipients/{recipient_id}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -393,7 +393,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/contactdb/recipients/{recipient_id}/lists'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -407,7 +407,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/contactdb/reserved_fields'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -445,7 +445,7 @@ request.body = {
 };
 request.method = 'POST'
 request.path = '/v3/contactdb/segments'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -459,7 +459,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/contactdb/segments'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -487,7 +487,7 @@ request.queryParams["segment_id"] = 'test_string'
  
 request.method = 'PATCH'
 request.path = '/v3/contactdb/segments/{segment_id}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -503,7 +503,7 @@ request.queryParams["segment_id"] = '1'
  
 request.method = 'GET'
 request.path = '/v3/contactdb/segments/{segment_id}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -519,7 +519,7 @@ request.queryParams["delete_contacts"] = 'true'
  
 request.method = 'DELETE'
 request.path = '/v3/contactdb/segments/{segment_id}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -536,7 +536,7 @@ request.queryParams["page"] = '1'
  
 request.method = 'GET'
 request.path = '/v3/contactdb/segments/{segment_id}/recipients'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)

--- a/examples/contactdb/contactdb.js
+++ b/examples/contactdb/contactdb.js
@@ -1,4 +1,4 @@
-var sg = require('sendgrid').SendGrid(process.env.SENDGRID_API_KEY)
+var sg = require('sendgrid')(process.env.SENDGRID_API_KEY)
 
 ///////////////////////////////////////////////////
 // Create a Custom Field

--- a/examples/devices/devices.js
+++ b/examples/devices/devices.js
@@ -14,7 +14,7 @@ request.queryParams["aggregated_by"] = 'day'
  
 request.method = 'GET'
 request.path = '/v3/devices/stats'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)

--- a/examples/devices/devices.js
+++ b/examples/devices/devices.js
@@ -1,4 +1,4 @@
-var sg = require('sendgrid').SendGrid(process.env.SENDGRID_API_KEY)
+var sg = require('sendgrid')(process.env.SENDGRID_API_KEY)
 
 ///////////////////////////////////////////////////
 // Retrieve email statistics by device type.

--- a/examples/geo/geo.js
+++ b/examples/geo/geo.js
@@ -1,4 +1,4 @@
-var sg = require('sendgrid').SendGrid(process.env.SENDGRID_API_KEY)
+var sg = require('sendgrid')(process.env.SENDGRID_API_KEY)
 
 ///////////////////////////////////////////////////
 // Retrieve email statistics by country and state/province.

--- a/examples/geo/geo.js
+++ b/examples/geo/geo.js
@@ -15,7 +15,7 @@ request.queryParams["end_date"] = '2016-04-01'
  
 request.method = 'GET'
 request.path = '/v3/geo/stats'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)

--- a/examples/helpers/mail/example.js
+++ b/examples/helpers/mail/example.js
@@ -144,7 +144,7 @@ function send(toSend){
   requestPost.method = 'POST'
   requestPost.path = '/v3/mail/send'
   requestPost.body = requestBody
-  sg.API(requestPost, function (response) {
+  sg.API(requestPost, function (error, response) {
     console.log(response.statusCode)
     console.log(response.body)
     console.log(response.headers)

--- a/examples/helpers/mail/example.js
+++ b/examples/helpers/mail/example.js
@@ -136,7 +136,7 @@ function send(toSend){
   console.log(JSON.stringify(toSend, null, 2))
   //console.log(JSON.stringify(toSend))
 
-  var sg = require('sendgrid').SendGrid(process.env.SENDGRID_API_KEY)
+  var sg = require('sendgrid')(process.env.SENDGRID_API_KEY)
 
   var requestBody = toSend
   var emptyRequest = require('sendgrid-rest').request

--- a/examples/ips/ips.js
+++ b/examples/ips/ips.js
@@ -14,7 +14,7 @@ request.queryParams["subuser"] = 'test_string'
  
 request.method = 'GET'
 request.path = '/v3/ips'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -28,7 +28,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/ips/assigned'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -45,7 +45,7 @@ request.body = {
 };
 request.method = 'POST'
 request.path = '/v3/ips/pools'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -59,7 +59,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/ips/pools'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -76,7 +76,7 @@ request.body = {
 };
 request.method = 'PUT'
 request.path = '/v3/ips/pools/{pool_name}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -90,7 +90,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/ips/pools/{pool_name}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -104,7 +104,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'DELETE'
 request.path = '/v3/ips/pools/{pool_name}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -121,7 +121,7 @@ request.body = {
 };
 request.method = 'POST'
 request.path = '/v3/ips/pools/{pool_name}/ips'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -135,7 +135,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'DELETE'
 request.path = '/v3/ips/pools/{pool_name}/ips/{ip}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -152,7 +152,7 @@ request.body = {
 };
 request.method = 'POST'
 request.path = '/v3/ips/warmup'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -166,7 +166,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/ips/warmup'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -180,7 +180,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/ips/warmup/{ip_address}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -194,7 +194,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'DELETE'
 request.path = '/v3/ips/warmup/{ip_address}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -208,7 +208,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/ips/{ip_address}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)

--- a/examples/ips/ips.js
+++ b/examples/ips/ips.js
@@ -1,4 +1,4 @@
-var sg = require('sendgrid').SendGrid(process.env.SENDGRID_API_KEY)
+var sg = require('sendgrid')(process.env.SENDGRID_API_KEY)
 
 ///////////////////////////////////////////////////
 // Retrieve all IP addresses

--- a/examples/mail/mail.js
+++ b/examples/mail/mail.js
@@ -8,7 +8,7 @@ var sg = require('sendgrid').SendGrid(process.env.SENDGRID_API_KEY)
 var request = sg.emptyRequest()
 request.method = 'POST'
 request.path = '/v3/mail/batch'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -22,7 +22,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/mail/batch/{batch_id}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -175,7 +175,7 @@ request.body = {
 };
 request.method = 'POST'
 request.path = '/v3/mail/send'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)

--- a/examples/mail/mail.js
+++ b/examples/mail/mail.js
@@ -1,4 +1,4 @@
-var sg = require('sendgrid').SendGrid(process.env.SENDGRID_API_KEY)
+var sg = require('sendgrid')(process.env.SENDGRID_API_KEY)
 
 ///////////////////////////////////////////////////
 // Create a batch ID

--- a/examples/mailboxproviders/mailboxproviders.js
+++ b/examples/mailboxproviders/mailboxproviders.js
@@ -1,4 +1,4 @@
-var sg = require('sendgrid').SendGrid(process.env.SENDGRID_API_KEY)
+var sg = require('sendgrid')(process.env.SENDGRID_API_KEY)
 
 ///////////////////////////////////////////////////
 // Retrieve email statistics by mailbox provider.

--- a/examples/mailboxproviders/mailboxproviders.js
+++ b/examples/mailboxproviders/mailboxproviders.js
@@ -15,7 +15,7 @@ request.queryParams["end_date"] = '2016-04-01'
  
 request.method = 'GET'
 request.path = '/v3/mailbox_providers/stats'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)

--- a/examples/mailsettings/mailsettings.js
+++ b/examples/mailsettings/mailsettings.js
@@ -11,7 +11,7 @@ request.queryParams["limit"] = '1'
  
 request.method = 'GET'
 request.path = '/v3/mail_settings'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -32,7 +32,7 @@ request.body = {
 };
 request.method = 'PATCH'
 request.path = '/v3/mail_settings/address_whitelist'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -46,7 +46,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/mail_settings/address_whitelist'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -64,7 +64,7 @@ request.body = {
 };
 request.method = 'PATCH'
 request.path = '/v3/mail_settings/bcc'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -78,7 +78,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/mail_settings/bcc'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -97,7 +97,7 @@ request.body = {
 };
 request.method = 'PATCH'
 request.path = '/v3/mail_settings/bounce_purge'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -111,7 +111,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/mail_settings/bounce_purge'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -130,7 +130,7 @@ request.body = {
 };
 request.method = 'PATCH'
 request.path = '/v3/mail_settings/footer'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -144,7 +144,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/mail_settings/footer'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -162,7 +162,7 @@ request.body = {
 };
 request.method = 'PATCH'
 request.path = '/v3/mail_settings/forward_bounce'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -176,7 +176,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/mail_settings/forward_bounce'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -194,7 +194,7 @@ request.body = {
 };
 request.method = 'PATCH'
 request.path = '/v3/mail_settings/forward_spam'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -208,7 +208,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/mail_settings/forward_spam'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -225,7 +225,7 @@ request.body = {
 };
 request.method = 'PATCH'
 request.path = '/v3/mail_settings/plain_content'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -239,7 +239,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/mail_settings/plain_content'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -258,7 +258,7 @@ request.body = {
 };
 request.method = 'PATCH'
 request.path = '/v3/mail_settings/spam_check'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -272,7 +272,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/mail_settings/spam_check'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -290,7 +290,7 @@ request.body = {
 };
 request.method = 'PATCH'
 request.path = '/v3/mail_settings/template'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -304,7 +304,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/mail_settings/template'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)

--- a/examples/mailsettings/mailsettings.js
+++ b/examples/mailsettings/mailsettings.js
@@ -1,4 +1,4 @@
-var sg = require('sendgrid').SendGrid(process.env.SENDGRID_API_KEY)
+var sg = require('sendgrid')(process.env.SENDGRID_API_KEY)
 
 ///////////////////////////////////////////////////
 // Retrieve all mail settings

--- a/examples/partnersettings/partnersettings.js
+++ b/examples/partnersettings/partnersettings.js
@@ -1,4 +1,4 @@
-var sg = require('sendgrid').SendGrid(process.env.SENDGRID_API_KEY)
+var sg = require('sendgrid')(process.env.SENDGRID_API_KEY)
 
 ///////////////////////////////////////////////////
 // Returns a list of all partner settings.

--- a/examples/partnersettings/partnersettings.js
+++ b/examples/partnersettings/partnersettings.js
@@ -11,7 +11,7 @@ request.queryParams["limit"] = '1'
  
 request.method = 'GET'
 request.path = '/v3/partner_settings'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -30,7 +30,7 @@ request.body = {
 };
 request.method = 'PATCH'
 request.path = '/v3/partner_settings/new_relic'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -44,7 +44,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/partner_settings/new_relic'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)

--- a/examples/scopes/scopes.js
+++ b/examples/scopes/scopes.js
@@ -1,4 +1,4 @@
-var sg = require('sendgrid').SendGrid(process.env.SENDGRID_API_KEY)
+var sg = require('sendgrid')(process.env.SENDGRID_API_KEY)
 
 ///////////////////////////////////////////////////
 // Retrieve a list of scopes for which this user has access.

--- a/examples/scopes/scopes.js
+++ b/examples/scopes/scopes.js
@@ -8,7 +8,7 @@ var sg = require('sendgrid').SendGrid(process.env.SENDGRID_API_KEY)
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/scopes'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)

--- a/examples/senders/senders.js
+++ b/examples/senders/senders.js
@@ -1,4 +1,4 @@
-var sg = require('sendgrid').SendGrid(process.env.SENDGRID_API_KEY)
+var sg = require('sendgrid')(process.env.SENDGRID_API_KEY)
 
 ///////////////////////////////////////////////////
 // Create a Sender Identity

--- a/examples/senders/senders.js
+++ b/examples/senders/senders.js
@@ -25,7 +25,7 @@ request.body = {
 };
 request.method = 'POST'
 request.path = '/v3/senders'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -39,7 +39,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/senders'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -70,7 +70,7 @@ request.body = {
 };
 request.method = 'PATCH'
 request.path = '/v3/senders/{sender_id}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -84,7 +84,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/senders/{sender_id}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -98,7 +98,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'DELETE'
 request.path = '/v3/senders/{sender_id}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -112,7 +112,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'POST'
 request.path = '/v3/senders/{sender_id}/resend_verification'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)

--- a/examples/stats/stats.js
+++ b/examples/stats/stats.js
@@ -14,7 +14,7 @@ request.queryParams["aggregated_by"] = 'day'
  
 request.method = 'GET'
 request.path = '/v3/stats'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)

--- a/examples/stats/stats.js
+++ b/examples/stats/stats.js
@@ -1,4 +1,4 @@
-var sg = require('sendgrid').SendGrid(process.env.SENDGRID_API_KEY)
+var sg = require('sendgrid')(process.env.SENDGRID_API_KEY)
 
 ///////////////////////////////////////////////////
 // Retrieve global email statistics

--- a/examples/subusers/subusers.js
+++ b/examples/subusers/subusers.js
@@ -1,4 +1,4 @@
-var sg = require('sendgrid').SendGrid(process.env.SENDGRID_API_KEY)
+var sg = require('sendgrid')(process.env.SENDGRID_API_KEY)
 
 ///////////////////////////////////////////////////
 // Create Subuser

--- a/examples/subusers/subusers.js
+++ b/examples/subusers/subusers.js
@@ -17,7 +17,7 @@ request.body = {
 };
 request.method = 'POST'
 request.path = '/v3/subusers'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -35,7 +35,7 @@ request.queryParams["username"] = 'test_string'
  
 request.method = 'GET'
 request.path = '/v3/subusers'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -51,7 +51,7 @@ request.queryParams["usernames"] = 'test_string'
  
 request.method = 'GET'
 request.path = '/v3/subusers/reputations'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -72,7 +72,7 @@ request.queryParams["end_date"] = '2016-04-01'
  
 request.method = 'GET'
 request.path = '/v3/subusers/stats'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -93,7 +93,7 @@ request.queryParams["subuser"] = 'test_string'
  
 request.method = 'GET'
 request.path = '/v3/subusers/stats/monthly'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -115,7 +115,7 @@ request.queryParams["end_date"] = '2016-04-01'
  
 request.method = 'GET'
 request.path = '/v3/subusers/stats/sums'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -132,7 +132,7 @@ request.body = {
 };
 request.method = 'PATCH'
 request.path = '/v3/subusers/{subuser_name}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -146,7 +146,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'DELETE'
 request.path = '/v3/subusers/{subuser_name}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -163,7 +163,7 @@ request.body = [
 ];
 request.method = 'PUT'
 request.path = '/v3/subusers/{subuser_name}/ips'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -181,7 +181,7 @@ request.body = {
 };
 request.method = 'PUT'
 request.path = '/v3/subusers/{subuser_name}/monitor'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -199,7 +199,7 @@ request.body = {
 };
 request.method = 'POST'
 request.path = '/v3/subusers/{subuser_name}/monitor'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -213,7 +213,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/subusers/{subuser_name}/monitor'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -227,7 +227,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'DELETE'
 request.path = '/v3/subusers/{subuser_name}/monitor'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -247,7 +247,7 @@ request.queryParams["date"] = 'test_string'
  
 request.method = 'GET'
 request.path = '/v3/subusers/{subuser_name}/stats/monthly'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)

--- a/examples/suppression/suppression.js
+++ b/examples/suppression/suppression.js
@@ -13,7 +13,7 @@ request.queryParams["start_time"] = '1'
  
 request.method = 'GET'
 request.path = '/v3/suppression/blocks'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -34,7 +34,7 @@ request.body = {
 };
 request.method = 'DELETE'
 request.path = '/v3/suppression/blocks'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -48,7 +48,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/suppression/blocks/{email}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -62,7 +62,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'DELETE'
 request.path = '/v3/suppression/blocks/{email}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -79,7 +79,7 @@ request.queryParams["start_time"] = '1'
  
 request.method = 'GET'
 request.path = '/v3/suppression/bounces'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -100,7 +100,7 @@ request.body = {
 };
 request.method = 'DELETE'
 request.path = '/v3/suppression/bounces'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -114,7 +114,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/suppression/bounces/{email}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -130,7 +130,7 @@ request.queryParams["email_address"] = 'example@example.com'
  
 request.method = 'DELETE'
 request.path = '/v3/suppression/bounces/{email}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -149,7 +149,7 @@ request.queryParams["start_time"] = '1'
  
 request.method = 'GET'
 request.path = '/v3/suppression/invalid_emails'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -170,7 +170,7 @@ request.body = {
 };
 request.method = 'DELETE'
 request.path = '/v3/suppression/invalid_emails'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -184,7 +184,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/suppression/invalid_emails/{email}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -198,7 +198,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'DELETE'
 request.path = '/v3/suppression/invalid_emails/{email}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -212,7 +212,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/suppression/spam_report/{email}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -226,7 +226,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'DELETE'
 request.path = '/v3/suppression/spam_report/{email}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -245,7 +245,7 @@ request.queryParams["start_time"] = '1'
  
 request.method = 'GET'
 request.path = '/v3/suppression/spam_reports'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -266,7 +266,7 @@ request.body = {
 };
 request.method = 'DELETE'
 request.path = '/v3/suppression/spam_reports'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -285,7 +285,7 @@ request.queryParams["start_time"] = '1'
  
 request.method = 'GET'
 request.path = '/v3/suppression/unsubscribes'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)

--- a/examples/suppression/suppression.js
+++ b/examples/suppression/suppression.js
@@ -1,4 +1,4 @@
-var sg = require('sendgrid').SendGrid(process.env.SENDGRID_API_KEY)
+var sg = require('sendgrid')(process.env.SENDGRID_API_KEY)
 
 ///////////////////////////////////////////////////
 // Retrieve all blocks

--- a/examples/templates/templates.js
+++ b/examples/templates/templates.js
@@ -11,7 +11,7 @@ request.body = {
 };
 request.method = 'POST'
 request.path = '/v3/templates'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -25,7 +25,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/templates'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -42,7 +42,7 @@ request.body = {
 };
 request.method = 'PATCH'
 request.path = '/v3/templates/{template_id}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -56,7 +56,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/templates/{template_id}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -70,7 +70,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'DELETE'
 request.path = '/v3/templates/{template_id}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -92,7 +92,7 @@ request.body = {
 };
 request.method = 'POST'
 request.path = '/v3/templates/{template_id}/versions'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -113,7 +113,7 @@ request.body = {
 };
 request.method = 'PATCH'
 request.path = '/v3/templates/{template_id}/versions/{version_id}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -127,7 +127,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/templates/{template_id}/versions/{version_id}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -141,7 +141,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'DELETE'
 request.path = '/v3/templates/{template_id}/versions/{version_id}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -155,7 +155,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'POST'
 request.path = '/v3/templates/{template_id}/versions/{version_id}/activate'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)

--- a/examples/templates/templates.js
+++ b/examples/templates/templates.js
@@ -1,4 +1,4 @@
-var sg = require('sendgrid').SendGrid(process.env.SENDGRID_API_KEY)
+var sg = require('sendgrid')(process.env.SENDGRID_API_KEY)
 
 ///////////////////////////////////////////////////
 // Create a transactional template.

--- a/examples/trackingsettings/trackingsettings.js
+++ b/examples/trackingsettings/trackingsettings.js
@@ -11,7 +11,7 @@ request.queryParams["limit"] = '1'
  
 request.method = 'GET'
 request.path = '/v3/tracking_settings'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -28,7 +28,7 @@ request.body = {
 };
 request.method = 'PATCH'
 request.path = '/v3/tracking_settings/click'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -42,7 +42,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/tracking_settings/click'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -64,7 +64,7 @@ request.body = {
 };
 request.method = 'PATCH'
 request.path = '/v3/tracking_settings/google_analytics'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -78,7 +78,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/tracking_settings/google_analytics'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -95,7 +95,7 @@ request.body = {
 };
 request.method = 'PATCH'
 request.path = '/v3/tracking_settings/open'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -109,7 +109,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/tracking_settings/open'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -131,7 +131,7 @@ request.body = {
 };
 request.method = 'PATCH'
 request.path = '/v3/tracking_settings/subscription'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -145,7 +145,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/tracking_settings/subscription'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)

--- a/examples/trackingsettings/trackingsettings.js
+++ b/examples/trackingsettings/trackingsettings.js
@@ -1,4 +1,4 @@
-var sg = require('sendgrid').SendGrid(process.env.SENDGRID_API_KEY)
+var sg = require('sendgrid')(process.env.SENDGRID_API_KEY)
 
 ///////////////////////////////////////////////////
 // Retrieve Tracking Settings

--- a/examples/user/user.js
+++ b/examples/user/user.js
@@ -1,4 +1,4 @@
-var sg = require('sendgrid').SendGrid(process.env.SENDGRID_API_KEY)
+var sg = require('sendgrid')(process.env.SENDGRID_API_KEY)
 
 ///////////////////////////////////////////////////
 // Get a user's account information.

--- a/examples/user/user.js
+++ b/examples/user/user.js
@@ -8,7 +8,7 @@ var sg = require('sendgrid').SendGrid(process.env.SENDGRID_API_KEY)
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/user/account'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -22,7 +22,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/user/credits'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -39,7 +39,7 @@ request.body = {
 };
 request.method = 'PUT'
 request.path = '/v3/user/email'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -53,7 +53,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/user/email'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -71,7 +71,7 @@ request.body = {
 };
 request.method = 'PUT'
 request.path = '/v3/user/password'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -90,7 +90,7 @@ request.body = {
 };
 request.method = 'PATCH'
 request.path = '/v3/user/profile'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -104,7 +104,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/user/profile'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -122,7 +122,7 @@ request.body = {
 };
 request.method = 'POST'
 request.path = '/v3/user/scheduled_sends'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -136,7 +136,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/user/scheduled_sends'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -153,7 +153,7 @@ request.body = {
 };
 request.method = 'PATCH'
 request.path = '/v3/user/scheduled_sends/{batch_id}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -167,7 +167,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/user/scheduled_sends/{batch_id}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -181,7 +181,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'DELETE'
 request.path = '/v3/user/scheduled_sends/{batch_id}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -199,7 +199,7 @@ request.body = {
 };
 request.method = 'PATCH'
 request.path = '/v3/user/settings/enforced_tls'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -213,7 +213,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/user/settings/enforced_tls'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -230,7 +230,7 @@ request.body = {
 };
 request.method = 'PUT'
 request.path = '/v3/user/username'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -244,7 +244,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/user/username'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -273,7 +273,7 @@ request.body = {
 };
 request.method = 'PATCH'
 request.path = '/v3/user/webhooks/event/settings'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -287,7 +287,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/user/webhooks/event/settings'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -304,7 +304,7 @@ request.body = {
 };
 request.method = 'POST'
 request.path = '/v3/user/webhooks/event/test'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -324,7 +324,7 @@ request.body = {
 };
 request.method = 'POST'
 request.path = '/v3/user/webhooks/parse/settings'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -338,7 +338,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/user/webhooks/parse/settings'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -357,7 +357,7 @@ request.body = {
 };
 request.method = 'PATCH'
 request.path = '/v3/user/webhooks/parse/settings/{hostname}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -371,7 +371,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/user/webhooks/parse/settings/{hostname}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -385,7 +385,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'DELETE'
 request.path = '/v3/user/webhooks/parse/settings/{hostname}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -405,7 +405,7 @@ request.queryParams["aggregated_by"] = 'day'
  
 request.method = 'GET'
 request.path = '/v3/user/webhooks/parse/stats'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)

--- a/examples/whitelabel/whitelabel.js
+++ b/examples/whitelabel/whitelabel.js
@@ -1,4 +1,4 @@
-var sg = require('sendgrid').SendGrid(process.env.SENDGRID_API_KEY)
+var sg = require('sendgrid')(process.env.SENDGRID_API_KEY)
 
 ///////////////////////////////////////////////////
 // Create a domain whitelabel.

--- a/examples/whitelabel/whitelabel.js
+++ b/examples/whitelabel/whitelabel.js
@@ -20,7 +20,7 @@ request.body = {
 };
 request.method = 'POST'
 request.path = '/v3/whitelabel/domains'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -40,7 +40,7 @@ request.queryParams["username"] = 'test_string'
  
 request.method = 'GET'
 request.path = '/v3/whitelabel/domains'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -54,7 +54,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/whitelabel/domains/default'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -68,7 +68,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/whitelabel/domains/subuser'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -82,7 +82,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'DELETE'
 request.path = '/v3/whitelabel/domains/subuser'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -100,7 +100,7 @@ request.body = {
 };
 request.method = 'PATCH'
 request.path = '/v3/whitelabel/domains/{domain_id}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -114,7 +114,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/whitelabel/domains/{domain_id}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -128,7 +128,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'DELETE'
 request.path = '/v3/whitelabel/domains/{domain_id}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -145,7 +145,7 @@ request.body = {
 };
 request.method = 'POST'
 request.path = '/v3/whitelabel/domains/{domain_id}/subuser'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -162,7 +162,7 @@ request.body = {
 };
 request.method = 'POST'
 request.path = '/v3/whitelabel/domains/{id}/ips'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -176,7 +176,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'DELETE'
 request.path = '/v3/whitelabel/domains/{id}/ips/{ip}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -190,7 +190,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'POST'
 request.path = '/v3/whitelabel/domains/{id}/validate'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -209,7 +209,7 @@ request.body = {
 };
 request.method = 'POST'
 request.path = '/v3/whitelabel/ips'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -227,7 +227,7 @@ request.queryParams["ip"] = 'test_string'
  
 request.method = 'GET'
 request.path = '/v3/whitelabel/ips'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -241,7 +241,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/whitelabel/ips/{id}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -255,7 +255,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'DELETE'
 request.path = '/v3/whitelabel/ips/{id}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -269,7 +269,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'POST'
 request.path = '/v3/whitelabel/ips/{id}/validate'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -291,7 +291,7 @@ request.queryParams["limit"] = '1'
  
 request.method = 'POST'
 request.path = '/v3/whitelabel/links'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -307,7 +307,7 @@ request.queryParams["limit"] = '1'
  
 request.method = 'GET'
 request.path = '/v3/whitelabel/links'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -323,7 +323,7 @@ request.queryParams["domain"] = 'test_string'
  
 request.method = 'GET'
 request.path = '/v3/whitelabel/links/default'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -339,7 +339,7 @@ request.queryParams["username"] = 'test_string'
  
 request.method = 'GET'
 request.path = '/v3/whitelabel/links/subuser'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -355,7 +355,7 @@ request.queryParams["username"] = 'test_string'
  
 request.method = 'DELETE'
 request.path = '/v3/whitelabel/links/subuser'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -372,7 +372,7 @@ request.body = {
 };
 request.method = 'PATCH'
 request.path = '/v3/whitelabel/links/{id}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -386,7 +386,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'GET'
 request.path = '/v3/whitelabel/links/{id}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -400,7 +400,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'DELETE'
 request.path = '/v3/whitelabel/links/{id}'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -414,7 +414,7 @@ sg.API(request, function (response) {
 var request = sg.emptyRequest()
 request.method = 'POST'
 request.path = '/v3/whitelabel/links/{id}/validate'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)
@@ -431,7 +431,7 @@ request.body = {
 };
 request.method = 'POST'
 request.path = '/v3/whitelabel/links/{link_id}/subuser'
-sg.API(request, function (response) {
+sg.API(request, function (error, response) {
   console.log(response.statusCode)
   console.log(response.body)
   console.log(response.headers)

--- a/index.js
+++ b/index.js
@@ -1,2 +1,2 @@
-exports = module.exports = require("./lib/sendgrid");
-exports.mail = require("./lib/helpers/mail/mail.js")
+exports = module.exports = require('./lib/sendgrid');
+exports.mail = require('./lib/helpers/mail/mail.js');

--- a/lib/helpers/error.js
+++ b/lib/helpers/error.js
@@ -1,0 +1,20 @@
+'use strict';
+
+//Error constructor
+function SendGridError(message) {
+  this.message = message;
+  if (Error.captureStackTrace) {
+    Error.captureStackTrace(this, this.constructor);
+  }
+  else {
+    this.stack = (new Error()).stack;
+  }
+}
+
+//Extend prototype
+SendGridError.prototype = new Error();
+SendGridError.prototype.constructor = SendGridError;
+SendGridError.prototype.name = 'SendGridError';
+
+//Export
+module.exports = SendGridError;

--- a/lib/helpers/mail/mail.js
+++ b/lib/helpers/mail/mail.js
@@ -1,652 +1,654 @@
-"use strict";
+'use strict';
 // This helper builds the request body for the v3 mail/send endpoint
 // Please see examples/helpers/mail/example.js for an usage example
 
 function ClickTracking(enable, enable_text) {
-  this.enable = enable
-  this.enable_text = enable_text
+  this.enable = enable;
+  this.enable_text = enable_text;
 
-  this.setEnable = function(enable){
-    this.enable = enable
-  }
+  this.setEnable = function(enable) {
+    this.enable = enable;
+  };
 
   this.getEnable = function() {
-    return this.enable
-  }
+    return this.enable;
+  };
 
-  this.setEnableText = function(enable_text){
-    this.enable_text = enable_text
-  }
+  this.setEnableText = function(enable_text) {
+    this.enable_text = enable_text;
+  };
 
   this.getEnableText = function() {
-    return this.enable_text
-  }
+    return this.enable_text;
+  };
 
-  this.toJSON = function () {
+  this.toJSON = function() {
     var json = {
       enable: this.getEnable(),
-      enable_text: this.getEnableText()
-    }
-    return json
-  }
+      enable_text: this.getEnableText(),
+    };
+    return json;
+  };
 
-  return this
+  return this;
 }
 
 function OpenTracking(enable, substitution_tag) {
-  this.enable = enable
-  this.substitution_tag = substitution_tag
+  this.enable = enable;
+  this.substitution_tag = substitution_tag;
 
-  this.setEnable = function(enable){
-    this.enable = enable
-  }
+  this.setEnable = function(enable) {
+    this.enable = enable;
+  };
 
   this.getEnable = function() {
-    return this.enable
-  }
+    return this.enable;
+  };
 
-  this.setSubscriptionTag = function(substitution_tag){
-    this.substitution_tag = substitution_tag
-  }
+  this.setSubscriptionTag = function(substitution_tag) {
+    this.substitution_tag = substitution_tag;
+  };
 
   this.getSubscriptionTag = function() {
-    return this.substitution_tag
-  }
+    return this.substitution_tag;
+  };
 
-  this.toJSON = function () {
+  this.toJSON = function() {
     var json = {
       enable: this.getEnable(),
-      substitution_tag: this.getSubscriptionTag()
-    }
-    return json
-  }
+      substitution_tag: this.getSubscriptionTag(),
+    };
+    return json;
+  };
 
-  return this
+  return this;
 }
 
 function SubscriptionTracking(enable, text, html, substitution_tag) {
-  this.enable = enable
-  this.text = text
-  this.html = html
-  this.substitution_tag = substitution_tag
+  this.enable = enable;
+  this.text = text;
+  this.html = html;
+  this.substitution_tag = substitution_tag;
 
-  this.setEnable = function(enable){
-    this.enable = enable
-  }
+  this.setEnable = function(enable) {
+    this.enable = enable;
+  };
 
   this.getEnable = function() {
-    return this.enable
-  }
+    return this.enable;
+  };
 
-  this.setText = function(text){
-    this.text = text
-  }
+  this.setText = function(text) {
+    this.text = text;
+  };
 
   this.getText = function() {
-    return this.text
-  }
+    return this.text;
+  };
 
-  this.setHtml = function(html){
-    this.html = html
-  }
+  this.setHtml = function(html) {
+    this.html = html;
+  };
 
   this.getHtml = function() {
-    return this.html
-  }
+    return this.html;
+  };
 
-  this.setSubstitutionTag = function(substitution_tag){
-    this.substitution_tag = substitution_tag
-  }
+  this.setSubstitutionTag = function(substitution_tag) {
+    this.substitution_tag = substitution_tag;
+  };
 
   this.getSubstitutionTag = function() {
-    return this.substitution_tag
-  }
+    return this.substitution_tag;
+  };
 
-  this.toJSON = function () {
+  this.toJSON = function() {
     var json = {
       enable: this.getEnable(),
       text: this.getText(),
       html: this.getHtml(),
-      substitution_tag: this.getSubstitutionTag()
-    }
-    return json
-  }
+      substitution_tag: this.getSubstitutionTag(),
+    };
+    return json;
+  };
 
-  return this
+  return this;
 }
 
-function Ganalytics(enable, utm_source, utm_medium, utm_term, utm_content, utm_campaign) {
-  this.enable = enable
-  this.utm_source = utm_source
-  this.utm_medium = utm_medium
-  this.utm_term = utm_term
-  this.utm_content = utm_content
-  this.utm_campaign = utm_campaign
+function Ganalytics(
+  enable, utm_source, utm_medium, utm_term, utm_content, utm_campaign
+) {
+  this.enable = enable;
+  this.utm_source = utm_source;
+  this.utm_medium = utm_medium;
+  this.utm_term = utm_term;
+  this.utm_content = utm_content;
+  this.utm_campaign = utm_campaign;
 
-  this.setEnable = function(enable){
-    this.enable = enable
-  }
+  this.setEnable = function(enable) {
+    this.enable = enable;
+  };
 
   this.getEnable = function() {
-    return this.enable
-  }
+    return this.enable;
+  };
 
-  this.setUtmSource = function(utm_source){
-    this.utm_source = utm_source
-  }
+  this.setUtmSource = function(utm_source) {
+    this.utm_source = utm_source;
+  };
 
   this.getUtmSource = function() {
-    return this.utm_source
-  }
+    return this.utm_source;
+  };
 
-  this.setUtmMedium = function(utm_medium){
-    this.utm_medium = utm_medium
-  }
+  this.setUtmMedium = function(utm_medium) {
+    this.utm_medium = utm_medium;
+  };
 
   this.getUtmMedium = function() {
-    return this.utm_medium
-  }
+    return this.utm_medium;
+  };
 
-  this.setUtmTerm = function(utm_term){
-    this.utm_term = utm_term
-  }
+  this.setUtmTerm = function(utm_term) {
+    this.utm_term = utm_term;
+  };
 
   this.getUtmTerm = function() {
-    return this.utm_term
-  }
+    return this.utm_term;
+  };
 
-  this.setUtmContent = function(utm_content){
-    this.utm_content = utm_content
-  }
+  this.setUtmContent = function(utm_content) {
+    this.utm_content = utm_content;
+  };
 
   this.getUtmContent = function() {
-    return this.utm_content
-  }
+    return this.utm_content;
+  };
 
-  this.setUtmCampaign = function(utm_campaign){
-    this.utm_campaign = utm_campaign
-  }
+  this.setUtmCampaign = function(utm_campaign) {
+    this.utm_campaign = utm_campaign;
+  };
 
   this.getUtmCampaign = function() {
-    return this.utm_campaign
-  }
+    return this.utm_campaign;
+  };
 
-  this.toJSON = function () {
+  this.toJSON = function() {
     var json = {
       enable: this.getEnable(),
       utm_source: this.getUtmSource(),
       utm_medium: this.getUtmMedium(),
       utm_term: this.getUtmTerm(),
       utm_content: this.getUtmContent(),
-      utm_campaign: this.getUtmCampaign()
-    }
-    return json
-  }
+      utm_campaign: this.getUtmCampaign(),
+    };
+    return json;
+  };
 
-  return this
+  return this;
 }
 
 function TrackingSettings() {
-  this.click_tracking = undefined
-  this.open_tracking = undefined
-  this.subscription_tracking = undefined
-  this.ganalytics = undefined
+  this.click_tracking = undefined;
+  this.open_tracking = undefined;
+  this.subscription_tracking = undefined;
+  this.ganalytics = undefined;
 
   this.setClickTracking = function(click_tracking) {
-    this.click_tracking = click_tracking
-  }
+    this.click_tracking = click_tracking;
+  };
 
   this.getClickTracking = function() {
-    return this.click_tracking
-  }
+    return this.click_tracking;
+  };
 
   this.setOpenTracking = function(open_tracking) {
-    this.open_tracking = open_tracking
-  }
+    this.open_tracking = open_tracking;
+  };
 
   this.getOpenTracking = function() {
-    return this.open_tracking
-  }
+    return this.open_tracking;
+  };
 
   this.setSubscriptionTracking = function(subscription_tracking) {
-    this.subscription_tracking = subscription_tracking
-  }
+    this.subscription_tracking = subscription_tracking;
+  };
 
   this.getSubscriptionTracking = function() {
-    return this.subscription_tracking
-  }
+    return this.subscription_tracking;
+  };
 
   this.setGanalytics = function(ganalytics) {
-    this.ganalytics = ganalytics
-  }
+    this.ganalytics = ganalytics;
+  };
 
   this.getGanalytics = function() {
-    return this.ganalytics
-  }
+    return this.ganalytics;
+  };
 
-  this.toJSON = function () {
+  this.toJSON = function() {
     var json = {
       click_tracking: this.getClickTracking(),
       open_tracking: this.getOpenTracking(),
       subscription_tracking: this.getSubscriptionTracking(),
       ganalytics: this.getGanalytics(),
-    }
-    return json
-  }
+    };
+    return json;
+  };
 
-  return this
+  return this;
 }
 
 function Bcc(enable, email) {
-  this.enable = enable
-  this.email = email
+  this.enable = enable;
+  this.email = email;
 
-  this.setEnable = function(enable){
-    this.enable = enable
-  }
+  this.setEnable = function(enable) {
+    this.enable = enable;
+  };
 
   this.getEnable = function() {
-    return this.enable
-  }
+    return this.enable;
+  };
 
-  this.setEmail = function(email){
-    this.email = email
-  }
+  this.setEmail = function(email) {
+    this.email = email;
+  };
 
   this.getEmail = function() {
-    return this.email
-  }
+    return this.email;
+  };
 
-  this.toJSON = function () {
+  this.toJSON = function() {
     var json = {
       enable: this.getEnable(),
-      email: this.getEmail()
-    }
-    return json
-  }
+      email: this.getEmail(),
+    };
+    return json;
+  };
 
-  return this
+  return this;
 }
 
 function BypassListManagement(enable) {
-  this.enable = enable
+  this.enable = enable;
 
   var json = {
-    enable: this.enable
-  }
+    enable: this.enable,
+  };
 
-  return json
+  return json;
 }
 
 function Footer(enable, text, html) {
-  this.enable = enable
-  this.text = text
-  this.html = html
+  this.enable = enable;
+  this.text = text;
+  this.html = html;
 
-
-  this.setEnable = function(enable){
-    this.enable = enable
-  }
+  this.setEnable = function(enable) {
+    this.enable = enable;
+  };
 
   this.getEnable = function() {
-    return this.enable
-  }
+    return this.enable;
+  };
 
-  this.setText = function(text){
-    this.text = text
-  }
+  this.setText = function(text) {
+    this.text = text;
+  };
 
   this.getText = function() {
-    return this.text
-  }
+    return this.text;
+  };
 
-  this.setHtml = function(html){
-    this.html = html
-  }
+  this.setHtml = function(html) {
+    this.html = html;
+  };
 
   this.getHtml = function() {
-    return this.html
-  }
+    return this.html;
+  };
 
-  this.toJSON = function () {
+  this.toJSON = function() {
     var json = {
       enable: this.getEnable(),
       text: this.getText(),
-      html: this.getHtml()
-    }
-    return json
-  }
+      html: this.getHtml(),
+    };
+    return json;
+  };
 
-  return this
+  return this;
 }
 
 function SandBoxMode(enable) {
-  this.enable = enable
+  this.enable = enable;
 
   var json = {
-    enable: this.enable
-  }
+    enable: this.enable,
+  };
 
-  return json
+  return json;
 }
 
 function SpamCheck(enable, threshold, post_to_url) {
-  this.enable = enable
-  this.threshold = threshold
-  this.post_to_url = post_to_url
+  this.enable = enable;
+  this.threshold = threshold;
+  this.post_to_url = post_to_url;
 
-
-  this.setEnable = function(enable){
-    this.enable = enable
-  }
+  this.setEnable = function(enable) {
+    this.enable = enable;
+  };
 
   this.getEnable = function() {
-    return this.enable
-  }
+    return this.enable;
+  };
 
-  this.setThreshold = function(threshold){
-    this.threshold = threshold
-  }
+  this.setThreshold = function(threshold) {
+    this.threshold = threshold;
+  };
 
   this.getThreshold = function() {
-    return this.threshold
-  }
+    return this.threshold;
+  };
 
-  this.setPostToUrl = function(post_to_url){
-    this.post_to_url = post_to_url
-  }
+  this.setPostToUrl = function(post_to_url) {
+    this.post_to_url = post_to_url;
+  };
 
   this.getPostToUrl = function() {
-    return this.post_to_url
-  }
+    return this.post_to_url;
+  };
 
-  this.toJSON = function () {
+  this.toJSON = function() {
     var json = {
       enable: this.getEnable(),
       threshold: this.getThreshold(),
-      post_to_url: this.getPostToUrl()
-    }
-    return json
-  }
+      post_to_url: this.getPostToUrl(),
+    };
+    return json;
+  };
 
-  return this
+  return this;
 }
 
 function MailSettings() {
-  this.bcc = undefined
-  this.bypass_list_management = undefined
-  this.footer = undefined
-  this.sandbox_mode = undefined
-  this.spam_check = undefined
+  this.bcc = undefined;
+  this.bypass_list_management = undefined;
+  this.footer = undefined;
+  this.sandbox_mode = undefined;
+  this.spam_check = undefined;
 
   this.setBcc = function(bcc) {
-    this.bcc = bcc
-  }
+    this.bcc = bcc;
+  };
 
   this.getBcc = function() {
-    return this.bcc
-  }
+    return this.bcc;
+  };
 
   this.setBypassListManagment = function(bypass_list_management) {
-    this.bypass_list_management = bypass_list_management
-  }
+    this.bypass_list_management = bypass_list_management;
+  };
 
   this.getBypassListManagement = function() {
-    return this.bypass_list_management
-  }
+    return this.bypass_list_management;
+  };
 
   this.setFooter = function(footer) {
-    this.footer = footer
-  }
+    this.footer = footer;
+  };
 
   this.getFooter = function() {
-    return this.footer
-  }
+    return this.footer;
+  };
 
   this.setSandBoxMode = function(sandbox_mode) {
-    this.sandbox_mode = sandbox_mode
-  }
+    this.sandbox_mode = sandbox_mode;
+  };
 
   this.getSandBoxMode = function() {
-    return this.sandbox_mode
-  }
+    return this.sandbox_mode;
+  };
 
   this.setSpamCheck = function(spam_check) {
-    this.spam_check = spam_check
-  }
+    this.spam_check = spam_check;
+  };
 
   this.getSpamCheck = function() {
-    return this.spam_check
-  }
+    return this.spam_check;
+  };
 
-  this.toJSON = function () {
+  this.toJSON = function() {
     var json = {
       bcc: this.getBcc(),
       bypass_list_management: this.getBypassListManagement(),
       footer: this.getFooter(),
       sandbox_mode: this.getSandBoxMode(),
-      spam_check: this.getSpamCheck()
-    }
-    return json
-  }
+      spam_check: this.getSpamCheck(),
+    };
+    return json;
+  };
 
-  return this
+  return this;
 }
 
 function Attachment() {
-  this.content = undefined
-  this.type = undefined
-  this.filename = undefined
-  this.disposition = undefined
-  this.content_id = undefined
+  this.content = undefined;
+  this.type = undefined;
+  this.filename = undefined;
+  this.disposition = undefined;
+  this.content_id = undefined;
 
   this.setContent = function(content) {
-    this.content = content
-  }
+    this.content = content;
+  };
 
   this.getContent = function() {
-    return this.content
-  }
+    return this.content;
+  };
 
   this.setType = function(type) {
-    this.type = type
-  }
+    this.type = type;
+  };
 
   this.getType = function() {
-    return this.type
-  }
+    return this.type;
+  };
 
   this.setFilename = function(filename) {
-    this.filename = filename
-  }
+    this.filename = filename;
+  };
 
   this.getFilename = function() {
-    return this.filename
-  }
+    return this.filename;
+  };
 
   this.setDisposition = function(disposition) {
-    this.disposition = disposition
-  }
+    this.disposition = disposition;
+  };
 
   this.getDisposition = function() {
-    return this.disposition
-  }
+    return this.disposition;
+  };
 
   this.setContentId = function(content_id) {
-    this.content_id = content_id
-  }
+    this.content_id = content_id;
+  };
 
   this.getContentId = function() {
-    return this.content_id
-  }
+    return this.content_id;
+  };
 
-  this.toJSON = function () {
+  this.toJSON = function() {
     var json = {
       content: this.getContent(),
       type: this.getType(),
       filename: this.getFilename(),
       disposition: this.getDisposition(),
-      content_id: this.getContentId()
-    }
-    return json
-  }
+      content_id: this.getContentId(),
+    };
+    return json;
+  };
 
-  return this
+  return this;
 }
 
 function Asm(group_id, groups_to_display) {
-  this.group_id = group_id
-  this.groups_to_display = groups_to_display
+  this.group_id = group_id;
+  this.groups_to_display = groups_to_display;
 
   var json = {
     group_id: this.group_id,
-    groups_to_display: this.groups_to_display
-  }
+    groups_to_display: this.groups_to_display,
+  };
 
-  return json
+  return json;
 }
 
 function Category(name) {
-  this.category = name
+  this.category = name;
 
   var json = {
-    category: this.category
-  }
+    category: this.category,
+  };
 
-  return json
+  return json;
 }
 
 function CustomArgs(key, value) {
-  this.key = key
-  this.value = value
+  this.key = key;
+  this.value = value;
 
-  var json = {}
-  json[this.key] = this.value
+  var json = {};
+  json[this.key] = this.value;
 
-  return json
+  return json;
 }
 
 function Substitution(key, value) {
-  this.key = key
-  this.value = value
+  this.key = key;
+  this.value = value;
 
-  var json = {}
-  json[this.key] = this.value
+  var json = {};
+  json[this.key] = this.value;
 
-  return json
+  return json;
 }
 
 function Section(key, value) {
-  this.key = key
-  this.value = value
+  this.key = key;
+  this.value = value;
 
-  var json = {}
-  json[this.key] = this.value
+  var json = {};
+  json[this.key] = this.value;
 
-  return json
+  return json;
 }
 
 function Header(key, value) {
-  this.key = key
-  this.value = value
+  this.key = key;
+  this.value = value;
 
-  var json = {}
-  json[this.key] = this.value
+  var json = {};
+  json[this.key] = this.value;
 
-  return json
+  return json;
 }
 
 function Personalization() {
-  this.tos = undefined
-  this.ccs = undefined
-  this.bccs = undefined
-  this.subject = undefined
-  this.headers = undefined
-  this.substitutions = undefined
-  this.custom_args = undefined
-  this.send_at = undefined
+  this.tos = undefined;
+  this.ccs = undefined;
+  this.bccs = undefined;
+  this.subject = undefined;
+  this.headers = undefined;
+  this.substitutions = undefined;
+  this.custom_args = undefined;
+  this.send_at = undefined;
 
   this.addTo = function(email) {
-    if(this.tos == undefined){
-      this.tos = []
+    if (this.tos === undefined) {
+      this.tos = [];
     }
-    this.tos.push(email)
-  }
+    this.tos.push(email);
+  };
 
   this.getTos = function() {
-    return this.tos
-  }
+    return this.tos;
+  };
 
   this.addCc = function(email) {
-    if(this.ccs == undefined){
-      this.ccs = []
+    if (this.ccs === undefined) {
+      this.ccs = [];
     }
-    this.ccs.push(email)
-  }
+    this.ccs.push(email);
+  };
 
   this.getCcs = function() {
-    return this.ccs
-  }
+    return this.ccs;
+  };
 
   this.addBcc = function(email) {
-    if(this.bccs == undefined){
-      this.bccs = []
+    if (this.bccs === undefined) {
+      this.bccs = [];
     }
-    this.bccs.push(email)
-  }
+    this.bccs.push(email);
+  };
 
   this.getBccs = function() {
-    return this.bccs
-  }
+    return this.bccs;
+  };
 
   this.setSubject = function(subject) {
-    this.subject = subject
-  }
+    this.subject = subject;
+  };
 
   this.getSubject = function() {
-    return this.subject
-  }
+    return this.subject;
+  };
 
   this.addHeader = function(header) {
-    if(this.headers == undefined){
-      this.headers = {}
+    if (this.headers === undefined) {
+      this.headers = {};
     }
-    this.headers[Object.keys(header)[0]] = header[Object.keys(header)[0]]
-  }
+    this.headers[Object.keys(header)[0]] = header[Object.keys(header)[0]];
+  };
 
   this.getHeaders = function() {
-    return this.headers
-  }
+    return this.headers;
+  };
 
   this.addSubstitution = function(substitution) {
-    if(this.substitutions == undefined){
-      this.substitutions = {}
+    if (this.substitutions === undefined) {
+      this.substitutions = {};
     }
-    this.substitutions[Object.keys(substitution)[0]] = substitution[Object.keys(substitution)[0]]
-  }
+    this.substitutions[Object.keys(substitution)[0]] =
+      substitution[Object.keys(substitution)[0]];
+  };
 
   this.getSubstitutions = function() {
-    return this.substitutions
-  }
+    return this.substitutions;
+  };
 
   this.addCustomArg = function(custom_arg) {
-    if(this.custom_args == undefined){
-      this.custom_args = {}
+    if (this.custom_args === undefined) {
+      this.custom_args = {};
     }
-    this.custom_args[Object.keys(custom_arg)[0]] = custom_arg[Object.keys(custom_arg)[0]]
-  }
+    this.custom_args[Object.keys(custom_arg)[0]] =
+      custom_arg[Object.keys(custom_arg)[0]];
+  };
 
   this.getCustomArgs = function() {
-    return this.custom_args
-  }
+    return this.custom_args;
+  };
 
   this.setSendAt = function(send_at) {
-    this.send_at = send_at
-  }
+    this.send_at = send_at;
+  };
 
   this.getSendAt = function() {
-    return this.send_at
-  }
+    return this.send_at;
+  };
 
   this.toJSON = function() {
     var json = {
@@ -657,220 +659,221 @@ function Personalization() {
       headers: this.getHeaders(),
       substitutions: this.getSubstitutions(),
       custom_args: this.getCustomArgs(),
-      send_at: this.getSendAt()
-    }
-    return json
-  }
+      send_at: this.getSendAt(),
+    };
+    return json;
+  };
 
-  return this
+  return this;
 }
 
 function Content(type, value) {
-  this.type = type
-  this.value = value
+  this.type = type;
+  this.value = value;
 
   var json = {
     type: this.type,
-    value: this.value
-  }
+    value: this.value,
+  };
 
-  return json
+  return json;
 }
 
 function Email(email, name) {
-  this.name = name
-  this.email = email
+  this.name = name;
+  this.email = email;
 
   var json = {
     email: this.email,
-    name: this.name
-  }
+    name: this.name,
+  };
 
-  return json
+  return json;
 }
 
 // This represents the full request body for a v3 /mail/send/
 function Mail(from_email, subject, to_email, content) {
-  this.from_email = undefined
-  this.personalizations = undefined
-  this.subject = undefined
-  this.contents = undefined
-  this.attachments = undefined
-  this.template_id = undefined
-  this.sections = undefined
-  this.headers = undefined
-  this.categories = undefined
-  this.send_at = undefined
-  this.batch_id = undefined
-  this.asm = undefined
-  this.ip_pool_name = undefined
-  this.mail_settings = undefined
-  this.reply_to = undefined
+  this.from_email = undefined;
+  this.personalizations = undefined;
+  this.subject = undefined;
+  this.contents = undefined;
+  this.attachments = undefined;
+  this.template_id = undefined;
+  this.sections = undefined;
+  this.headers = undefined;
+  this.categories = undefined;
+  this.send_at = undefined;
+  this.batch_id = undefined;
+  this.asm = undefined;
+  this.ip_pool_name = undefined;
+  this.mail_settings = undefined;
+  this.reply_to = undefined;
 
   this.setFrom = function(email) {
-    this.from_email = email
-  }
+    this.from_email = email;
+  };
 
   this.getFrom = function() {
     return this.from_email;
-  }
+  };
 
   this.addPersonalization = function(personalization) {
-    if(this.personalizations == undefined){
-      this.personalizations = []
+    if (this.personalizations === undefined) {
+      this.personalizations = [];
     }
     this.personalizations.push(personalization);
-  }
+  };
 
   this.getPersonalizations = function() {
-    return this.personalizations
-  }
+    return this.personalizations;
+  };
 
   this.setSubject = function(subject) {
-    this.subject = subject
-  }
+    this.subject = subject;
+  };
 
   this.getSubject = function() {
     return this.subject;
-  }
+  };
 
   this.addContent = function(content) {
-    if(this.contents == undefined){
-      this.contents = []
+    if (this.contents === undefined) {
+      this.contents = [];
     }
     this.contents.push(content);
-  }
+  };
 
   this.getContents = function() {
-    return this.contents
-  }
+    return this.contents;
+  };
 
   this.addAttachment = function(attachment) {
-    if(this.attachments == undefined){
-      this.attachments = []
+    if (this.attachments === undefined) {
+      this.attachments = [];
     }
     this.attachments.push(attachment);
-  }
+  };
 
   this.getAttachments = function() {
-    return this.attachments
-  }
+    return this.attachments;
+  };
 
   this.setTemplateId = function(template_id) {
-    this.template_id = template_id
-  }
+    this.template_id = template_id;
+  };
 
   this.getTemplateId = function() {
     return this.template_id;
-  }
+  };
 
   this.addSection = function(section) {
-    if(this.sections == undefined){
-      this.sections = {}
+    if (this.sections === undefined) {
+      this.sections = {};
     }
-    this.sections[Object.keys(section)[0]] = section[Object.keys(section)[0]]
-  }
+    this.sections[Object.keys(section)[0]] = section[Object.keys(section)[0]];
+  };
 
   this.getSections = function() {
-    return this.sections
-  }
+    return this.sections;
+  };
 
   this.addHeader = function(header) {
-    if(this.headers == undefined){
-      this.headers = {}
+    if (this.headers === undefined) {
+      this.headers = {};
     }
-    this.headers[Object.keys(header)[0]] = header[Object.keys(header)[0]]
-  }
+    this.headers[Object.keys(header)[0]] = header[Object.keys(header)[0]];
+  };
 
   this.getHeaders = function() {
-    return this.headers
-  }
+    return this.headers;
+  };
 
-  this.addCategory = function (category) {
-    if(this.categories == undefined){
-      this.categories = []
+  this.addCategory = function(category) {
+    if (this.categories === undefined) {
+      this.categories = [];
     }
-    this.categories.push(category["category"])
-  }
+    this.categories.push(category.category);
+  };
 
   this.getCategories = function() {
-    return this.categories
-  }
+    return this.categories;
+  };
 
   this.addCustomArg = function(custom_arg) {
-    if(this.custom_args == undefined){
-      this.custom_args = {}
+    if (this.custom_args === undefined) {
+      this.custom_args = {};
     }
-    this.custom_args[Object.keys(custom_arg)[0]] = custom_arg[Object.keys(custom_arg)[0]]
-  }
+    this.custom_args[Object.keys(custom_arg)[0]] =
+      custom_arg[Object.keys(custom_arg)[0]];
+  };
 
   this.getCustomArgs = function() {
-    return this.custom_args
-  }
+    return this.custom_args;
+  };
 
   this.setSendAt = function(send_at) {
-    this.send_at = send_at
-  }
+    this.send_at = send_at;
+  };
 
   this.getSendAt = function() {
-    return this.send_at
-  }
+    return this.send_at;
+  };
 
   this.setBatchId = function(batch_id) {
-    this.batch_id = batch_id
-  }
+    this.batch_id = batch_id;
+  };
 
   this.getBatchId = function() {
-    return this.batch_id
-  }
+    return this.batch_id;
+  };
 
   this.setAsm = function(asm) {
-    this.asm = asm
-  }
+    this.asm = asm;
+  };
 
   this.getAsm = function() {
-    return this.asm
-  }
+    return this.asm;
+  };
 
   this.setIpPoolName = function(ip_pool_name) {
-    this.ip_pool_name = ip_pool_name
-  }
+    this.ip_pool_name = ip_pool_name;
+  };
 
   this.getIpPoolName = function() {
-    return this.ip_pool_name
-  }
+    return this.ip_pool_name;
+  };
 
   this.addMailSettings = function(mail_settings) {
-    this.mail_settings = mail_settings
-  }
+    this.mail_settings = mail_settings;
+  };
 
   this.getMailSettings = function() {
-    return this.mail_settings
-  }
+    return this.mail_settings;
+  };
 
   this.addTrackingSettings = function(tracking_settings) {
-    this.tracking_settings = tracking_settings
-  }
+    this.tracking_settings = tracking_settings;
+  };
 
   this.getTrackingSettings = function() {
-    return this.tracking_settings
-  }
+    return this.tracking_settings;
+  };
 
   this.setReplyTo = function(reply_to) {
-    this.reply_to = reply_to
-  }
+    this.reply_to = reply_to;
+  };
 
   this.getReplyTo = function() {
     return this.reply_to;
-  }
+  };
 
-  if(from_email && subject && to_email && content){
-    this.setFrom(from_email)
-    var personalization = new Personalization()
-    personalization.addTo(to_email)
-    this.addPersonalization(personalization)
-    this.setSubject(subject)
-    this.addContent(content)
+  if (from_email && subject && to_email && content) {
+    this.setFrom(from_email);
+    var personalization = new Personalization();
+    personalization.addTo(to_email);
+    this.addPersonalization(personalization);
+    this.setSubject(subject);
+    this.addContent(content);
   }
 
   this.toJSON = function() {
@@ -891,17 +894,16 @@ function Mail(from_email, subject, to_email, content) {
       ip_pool_name: this.getIpPoolName(),
       mail_settings: this.getMailSettings(),
       tracking_settings: this.getTrackingSettings(),
-      reply_to: this.getReplyTo()
-    }
+      reply_to: this.getReplyTo(),
+    };
 
-    return json
-  }
+    return json;
+  };
 
-  return this
+  return this;
 }
 
-module.exports =
-{
+module.exports = {
   Email: Email,
   Mail: Mail,
   Personalization: Personalization,
@@ -923,5 +925,5 @@ module.exports =
   OpenTracking: OpenTracking,
   SubscriptionTracking: SubscriptionTracking,
   Ganalytics: Ganalytics,
-  TrackingSettings: TrackingSettings
-}
+  TrackingSettings: TrackingSettings,
+};

--- a/lib/sendgrid.js
+++ b/lib/sendgrid.js
@@ -75,7 +75,7 @@ function SendGrid(apiKey, host, globalHeaders) {
   var client = new Client(globalRequest);
 
   //Interact with the API with this function
-  this.API = function(request, callback) {
+  SendGrid.API = function(request, callback) {
 
     //If no callback provided, we will return a promise
     if (!callback) {
@@ -109,9 +109,9 @@ function SendGrid(apiKey, host, globalHeaders) {
   };
 
   //Set requests
-  this.emptyRequest = getEmptyRequest;
-  this.globalRequest = globalRequest;
-  return this;
+  SendGrid.emptyRequest = getEmptyRequest;
+  SendGrid.globalRequest = globalRequest;
+  return SendGrid;
 }
 
 //Try to use native promises by default

--- a/lib/sendgrid.js
+++ b/lib/sendgrid.js
@@ -1,41 +1,43 @@
-"use strict";
+/* eslint dot-notation: 'off' */
+'use strict';
 var package_json = require('./../package.json');
-var emptyRequest = JSON.parse(JSON.stringify(require('sendgrid-rest').emptyRequest));
+var emptyRequest = require('sendgrid-rest').emptyRequest;
 
 // SendGrid allows for quick and easy access to the v3 Web API
-function SendGrid (apiKey, host, globalHeaders) {
-  var Client = require('sendgrid-rest').Client
-  var globalRequest = JSON.parse(JSON.stringify(require('sendgrid-rest').emptyRequest));
-  globalRequest.host = host || "api.sendgrid.com";
-  globalRequest.headers['Authorization'] = 'Bearer '.concat(apiKey)
-  globalRequest.headers['User-Agent'] = 'sendgrid/' + package_json.version + ';nodejs'
-  globalRequest.headers['Accept'] = 'application/json'
+function SendGrid(apiKey, host, globalHeaders) {
+  var Client = require('sendgrid-rest').Client;
+  var globalRequest = this.emptyRequest();
+  globalRequest.host = host || 'api.sendgrid.com';
+  globalRequest.headers['Authorization'] = 'Bearer '.concat(apiKey);
+  globalRequest.headers['Accept'] = 'application/json';
+  globalRequest.headers['User-Agent'] =
+    'sendgrid/' + package_json.version + ';nodejs';
   if (globalHeaders) {
     for (var obj in globalHeaders) {
-      for (var key in globalHeaders[obj] ) {
-        globalRequest.headers[key] = globalHeaders[obj][key]
+      for (var key in globalHeaders[obj]) {
+        globalRequest.headers[key] = globalHeaders[obj][key];
       }
     }
   }
-  var client = new Client(globalRequest)
+  var client = new Client(globalRequest);
 
-  this.emptyRequest = function () {
-    return JSON.parse(JSON.stringify(require('sendgrid-rest').emptyRequest));
-  }
+  this.emptyRequest = function() {
+    return JSON.parse(JSON.stringify(emptyRequest));
+  };
 
   // Interact with the API with this function
   this.API = function(request, callback) {
-    client.API(request, function (response) {
-      callback(response)
-    })
+    client.API(request, function(response) {
+      callback(response);
+    });
   };
 
-  this.globalRequest = globalRequest
+  this.globalRequest = globalRequest;
   return this;
-};
+}
 
 module.exports =
 {
   SendGrid: SendGrid,
-  emptyRequest: emptyRequest
-}
+  emptyRequest: SendGrid.emptyRequest(),
+};

--- a/lib/sendgrid.js
+++ b/lib/sendgrid.js
@@ -1,8 +1,13 @@
 /* eslint dot-notation: 'off' */
 'use strict';
-var package_json = require('./../package.json');
-var emptyRequest = require('sendgrid-rest').emptyRequest;
-var Client = require('sendgrid-rest').Client;
+
+/**
+ * Dependencies
+ */
+var pkg = require('./../package.json');
+var sendgridRest = require('sendgrid-rest');
+var emptyRequest = sendgridRest.emptyRequest;
+var Client = sendgridRest.Client;
 var SendGridError = require('./helpers/error');
 
 /**
@@ -39,7 +44,7 @@ function makeHeaders(apiKey, globalHeaders) {
   var headers = {};
   headers['Authorization'] = 'Bearer '.concat(apiKey);
   headers['Accept'] = 'application/json';
-  headers['User-Agent'] = 'sendgrid/' + package_json.version + ';nodejs';
+  headers['User-Agent'] = 'sendgrid/' + pkg.version + ';nodejs';
   if (globalHeaders) {
     for (var obj in globalHeaders) {
       if (globalHeaders.hasOwnProperty(obj) &&
@@ -83,7 +88,9 @@ function SendGrid(apiKey, host, globalHeaders) {
             resolve(response);
           }
           else {
-            reject(response);
+            var error = new SendGridError('Response error');
+            error.response = response;
+            reject(error);
           }
         });
       });
@@ -111,7 +118,4 @@ function SendGrid(apiKey, host, globalHeaders) {
 SendGrid.Promise = Promise || null;
 
 //Export
-module.exports = {
-  SendGrid: SendGrid,
-  emptyRequest: getEmptyRequest(),
-};
+module.exports = SendGrid;

--- a/lib/sendgrid.js
+++ b/lib/sendgrid.js
@@ -3,10 +3,15 @@
 var package_json = require('./../package.json');
 var emptyRequest = require('sendgrid-rest').emptyRequest;
 
+//Helper to get empty request
+function getEmptyRequest() {
+  return JSON.parse(JSON.stringify(emptyRequest));
+}
+
 // SendGrid allows for quick and easy access to the v3 Web API
 function SendGrid(apiKey, host, globalHeaders) {
   var Client = require('sendgrid-rest').Client;
-  var globalRequest = this.emptyRequest();
+  var globalRequest = getEmptyRequest();
   globalRequest.host = host || 'api.sendgrid.com';
   globalRequest.headers['Authorization'] = 'Bearer '.concat(apiKey);
   globalRequest.headers['Accept'] = 'application/json';
@@ -21,9 +26,7 @@ function SendGrid(apiKey, host, globalHeaders) {
   }
   var client = new Client(globalRequest);
 
-  this.emptyRequest = function() {
-    return JSON.parse(JSON.stringify(emptyRequest));
-  };
+  this.emptyRequest = getEmptyRequest;
 
   // Interact with the API with this function
   this.API = function(request, callback) {
@@ -39,5 +42,5 @@ function SendGrid(apiKey, host, globalHeaders) {
 module.exports =
 {
   SendGrid: SendGrid,
-  emptyRequest: SendGrid.emptyRequest(),
+  emptyRequest: getEmptyRequest(),
 };

--- a/lib/sendgrid.js
+++ b/lib/sendgrid.js
@@ -2,45 +2,116 @@
 'use strict';
 var package_json = require('./../package.json');
 var emptyRequest = require('sendgrid-rest').emptyRequest;
+var Client = require('sendgrid-rest').Client;
+var SendGridError = require('./helpers/error');
 
-//Helper to get empty request
-function getEmptyRequest() {
-  return JSON.parse(JSON.stringify(emptyRequest));
+/**
+ * Helper to check if response is valid
+ */
+function isValidResponse(response) {
+  return (
+    response &&
+    response.statusCode &&
+    response.statusCode >= 200 &&
+    response.statusCode <= 299
+  );
 }
 
-// SendGrid allows for quick and easy access to the v3 Web API
-function SendGrid(apiKey, host, globalHeaders) {
-  var Client = require('sendgrid-rest').Client;
-  var globalRequest = getEmptyRequest();
-  globalRequest.host = host || 'api.sendgrid.com';
-  globalRequest.headers['Authorization'] = 'Bearer '.concat(apiKey);
-  globalRequest.headers['Accept'] = 'application/json';
-  globalRequest.headers['User-Agent'] =
-    'sendgrid/' + package_json.version + ';nodejs';
-  if (globalHeaders) {
-    for (var obj in globalHeaders) {
-      for (var key in globalHeaders[obj]) {
-        globalRequest.headers[key] = globalHeaders[obj][key];
+/**
+ * Helper to get a new empty request
+ */
+function getEmptyRequest(data) {
+  let request = JSON.parse(JSON.stringify(emptyRequest));
+  if (data && typeof data === 'object') {
+    for (var key in data) {
+      if (data.hasOwnProperty(key)) {
+        request[key] = JSON.parse(JSON.stringify(data[key]));
       }
     }
   }
+  return request;
+}
+
+/**
+ * Helper to make headers
+ */
+function makeHeaders(apiKey, globalHeaders) {
+  var headers = {};
+  headers['Authorization'] = 'Bearer '.concat(apiKey);
+  headers['Accept'] = 'application/json';
+  headers['User-Agent'] = 'sendgrid/' + package_json.version + ';nodejs';
+  if (globalHeaders) {
+    for (var obj in globalHeaders) {
+      if (globalHeaders.hasOwnProperty(obj) &&
+        typeof globalHeaders[obj] === 'object') {
+        for (var key in globalHeaders[obj]) {
+          if (globalHeaders[obj].hasOwnProperty(key)) {
+            headers[key] = globalHeaders[obj][key];
+          }
+        }
+      }
+    }
+  }
+  return headers;
+}
+
+/**
+ * SendGrid allows for quick and easy access to the v3 Web API
+ */
+function SendGrid(apiKey, host, globalHeaders) {
+
+  //Create global request
+  var globalRequest = getEmptyRequest({
+    host: host || 'api.sendgrid.com',
+    headers: makeHeaders(apiKey, globalHeaders),
+  });
+
+  //Initialize new client
   var client = new Client(globalRequest);
 
-  this.emptyRequest = getEmptyRequest;
-
-  // Interact with the API with this function
+  //Interact with the API with this function
   this.API = function(request, callback) {
+
+    //If no callback provided, we will return a promise
+    if (!callback) {
+      if (!SendGrid.Promise) {
+        throw new SendGridError('Promise API not supported');
+      }
+      return new SendGrid.Promise(function(resolve, reject) {
+        client.API(request, function(response) {
+          if (isValidResponse(response)) {
+            resolve(response);
+          }
+          else {
+            reject(response);
+          }
+        });
+      });
+    }
+
+    //Use callback
     client.API(request, function(response) {
-      callback(response);
+      if (isValidResponse(response)) {
+        callback(null, response);
+      }
+      else {
+        var error = new SendGridError('Response error');
+        callback(error, response);
+      }
     });
   };
 
+  //Set requests
+  this.emptyRequest = getEmptyRequest;
   this.globalRequest = globalRequest;
   return this;
 }
 
-module.exports =
-{
+//Try to use native promises by default
+SendGrid.Promise = Promise || null;
+
+//Export
+module.exports = {
   SendGrid: SendGrid,
   emptyRequest: getEmptyRequest(),
 };

--- a/package.json
+++ b/package.json
@@ -27,8 +27,6 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "eslint": "^3.1.0",
-    "eslint-config-standard": "^5.1.0",
-    "eslint-plugin-standard": "^1.3.2",
     "mocha": "^2.4.5"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "mocha": "^2.4.5"
   },
   "scripts": {
-    "pretest": "eslint . --fix",
+    "lint": "eslint . --fix",
     "test": "mocha"
   },
   "tags": [

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "Brandon West <brandon.west@sendgrid.com>",
     "Scott Motte <scott.motte@sendgrid.com>",
     "Robert Acosta <robert.acosta@sendgrid.com>",
-    "Elmer Thomas <elmer.thomas@sendgrid.com>"
+    "Elmer Thomas <elmer.thomas@sendgrid.com>",
+    "Adam Buczynski <me@adambuczynski.com>"
   ],
   "name": "sendgrid",
   "description": "Official SendGrid NodeJS library.",
@@ -25,12 +26,13 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
-    "eslint": "^2.7.0",
+    "eslint": "^3.1.0",
     "eslint-config-standard": "^5.1.0",
     "eslint-plugin-standard": "^1.3.2",
     "mocha": "^2.4.5"
   },
   "scripts": {
+    "pretest": "eslint . --fix",
     "test": "mocha"
   },
   "tags": [

--- a/test/test.js
+++ b/test/test.js
@@ -22,7 +22,7 @@ describe('test_access_settings_activity_get', function () {
   request.path = '/v3/access_settings/activity'
   request.headers['X-Mock'] = 200
   it('test_access_settings_activity_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -62,7 +62,7 @@ describe('test_access_settings_whitelist_post', function () {
   request.path = '/v3/access_settings/whitelist'
   request.headers['X-Mock'] = 201
   it('test_access_settings_whitelist_post had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 201, 'response code is not correct')
       done();
     })
@@ -89,7 +89,7 @@ describe('test_access_settings_whitelist_get', function () {
   request.path = '/v3/access_settings/whitelist'
   request.headers['X-Mock'] = 200
   it('test_access_settings_whitelist_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -123,7 +123,7 @@ describe('test_access_settings_whitelist_delete', function () {
   request.path = '/v3/access_settings/whitelist'
   request.headers['X-Mock'] = 204
   it('test_access_settings_whitelist_delete had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 204, 'response code is not correct')
       done();
     })
@@ -150,7 +150,7 @@ describe('test_access_settings_whitelist__rule_id__get', function () {
   request.path = '/v3/access_settings/whitelist/{rule_id}'
   request.headers['X-Mock'] = 200
   it('test_access_settings_whitelist__rule_id__get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -178,7 +178,7 @@ describe('test_access_settings_whitelist__rule_id__delete', function () {
   request.path = '/v3/access_settings/whitelist/{rule_id}'
   request.headers['X-Mock'] = 204
   it('test_access_settings_whitelist__rule_id__delete had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 204, 'response code is not correct')
       done();
     })
@@ -210,7 +210,7 @@ describe('test_alerts_post', function () {
   request.path = '/v3/alerts'
   request.headers['X-Mock'] = 201
   it('test_alerts_post had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 201, 'response code is not correct')
       done();
     })
@@ -237,7 +237,7 @@ describe('test_alerts_get', function () {
   request.path = '/v3/alerts'
   request.headers['X-Mock'] = 200
   it('test_alerts_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -267,7 +267,7 @@ describe('test_alerts__alert_id__patch', function () {
   request.path = '/v3/alerts/{alert_id}'
   request.headers['X-Mock'] = 200
   it('test_alerts__alert_id__patch had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -294,7 +294,7 @@ describe('test_alerts__alert_id__get', function () {
   request.path = '/v3/alerts/{alert_id}'
   request.headers['X-Mock'] = 200
   it('test_alerts__alert_id__get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -322,7 +322,7 @@ describe('test_alerts__alert_id__delete', function () {
   request.path = '/v3/alerts/{alert_id}'
   request.headers['X-Mock'] = 204
   it('test_alerts__alert_id__delete had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 204, 'response code is not correct')
       done();
     })
@@ -358,7 +358,7 @@ describe('test_api_keys_post', function () {
   request.path = '/v3/api_keys'
   request.headers['X-Mock'] = 201
   it('test_api_keys_post had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 201, 'response code is not correct')
       done();
     })
@@ -387,7 +387,7 @@ describe('test_api_keys_get', function () {
   request.path = '/v3/api_keys'
   request.headers['X-Mock'] = 200
   it('test_api_keys_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -421,7 +421,7 @@ describe('test_api_keys__api_key_id__put', function () {
   request.path = '/v3/api_keys/{api_key_id}'
   request.headers['X-Mock'] = 200
   it('test_api_keys__api_key_id__put had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -451,7 +451,7 @@ describe('test_api_keys__api_key_id__patch', function () {
   request.path = '/v3/api_keys/{api_key_id}'
   request.headers['X-Mock'] = 200
   it('test_api_keys__api_key_id__patch had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -478,7 +478,7 @@ describe('test_api_keys__api_key_id__get', function () {
   request.path = '/v3/api_keys/{api_key_id}'
   request.headers['X-Mock'] = 200
   it('test_api_keys__api_key_id__get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -506,7 +506,7 @@ describe('test_api_keys__api_key_id__delete', function () {
   request.path = '/v3/api_keys/{api_key_id}'
   request.headers['X-Mock'] = 204
   it('test_api_keys__api_key_id__delete had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 204, 'response code is not correct')
       done();
     })
@@ -538,7 +538,7 @@ describe('test_asm_groups_post', function () {
   request.path = '/v3/asm/groups'
   request.headers['X-Mock'] = 201
   it('test_asm_groups_post had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 201, 'response code is not correct')
       done();
     })
@@ -567,7 +567,7 @@ describe('test_asm_groups_get', function () {
   request.path = '/v3/asm/groups'
   request.headers['X-Mock'] = 200
   it('test_asm_groups_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -599,7 +599,7 @@ describe('test_asm_groups__group_id__patch', function () {
   request.path = '/v3/asm/groups/{group_id}'
   request.headers['X-Mock'] = 201
   it('test_asm_groups__group_id__patch had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 201, 'response code is not correct')
       done();
     })
@@ -626,7 +626,7 @@ describe('test_asm_groups__group_id__get', function () {
   request.path = '/v3/asm/groups/{group_id}'
   request.headers['X-Mock'] = 200
   it('test_asm_groups__group_id__get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -654,7 +654,7 @@ describe('test_asm_groups__group_id__delete', function () {
   request.path = '/v3/asm/groups/{group_id}'
   request.headers['X-Mock'] = 204
   it('test_asm_groups__group_id__delete had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 204, 'response code is not correct')
       done();
     })
@@ -687,7 +687,7 @@ describe('test_asm_groups__group_id__suppressions_post', function () {
   request.path = '/v3/asm/groups/{group_id}/suppressions'
   request.headers['X-Mock'] = 201
   it('test_asm_groups__group_id__suppressions_post had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 201, 'response code is not correct')
       done();
     })
@@ -714,7 +714,7 @@ describe('test_asm_groups__group_id__suppressions_get', function () {
   request.path = '/v3/asm/groups/{group_id}/suppressions'
   request.headers['X-Mock'] = 200
   it('test_asm_groups__group_id__suppressions_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -748,7 +748,7 @@ describe('test_asm_groups__group_id__suppressions_search_post', function () {
   request.path = '/v3/asm/groups/{group_id}/suppressions/search'
   request.headers['X-Mock'] = 200
   it('test_asm_groups__group_id__suppressions_search_post had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -776,7 +776,7 @@ describe('test_asm_groups__group_id__suppressions__email__delete', function () {
   request.path = '/v3/asm/groups/{group_id}/suppressions/{email}'
   request.headers['X-Mock'] = 204
   it('test_asm_groups__group_id__suppressions__email__delete had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 204, 'response code is not correct')
       done();
     })
@@ -803,7 +803,7 @@ describe('test_asm_suppressions_get', function () {
   request.path = '/v3/asm/suppressions'
   request.headers['X-Mock'] = 200
   it('test_asm_suppressions_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -836,7 +836,7 @@ describe('test_asm_suppressions_global_post', function () {
   request.path = '/v3/asm/suppressions/global'
   request.headers['X-Mock'] = 201
   it('test_asm_suppressions_global_post had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 201, 'response code is not correct')
       done();
     })
@@ -863,7 +863,7 @@ describe('test_asm_suppressions_global__email__get', function () {
   request.path = '/v3/asm/suppressions/global/{email}'
   request.headers['X-Mock'] = 200
   it('test_asm_suppressions_global__email__get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -891,7 +891,7 @@ describe('test_asm_suppressions_global__email__delete', function () {
   request.path = '/v3/asm/suppressions/global/{email}'
   request.headers['X-Mock'] = 204
   it('test_asm_suppressions_global__email__delete had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 204, 'response code is not correct')
       done();
     })
@@ -918,7 +918,7 @@ describe('test_asm_suppressions__email__get', function () {
   request.path = '/v3/asm/suppressions/{email}'
   request.headers['X-Mock'] = 200
   it('test_asm_suppressions__email__get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -952,7 +952,7 @@ describe('test_browsers_stats_get', function () {
   request.path = '/v3/browsers/stats'
   request.headers['X-Mock'] = 200
   it('test_browsers_stats_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -999,7 +999,7 @@ describe('test_campaigns_post', function () {
   request.path = '/v3/campaigns'
   request.headers['X-Mock'] = 201
   it('test_campaigns_post had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 201, 'response code is not correct')
       done();
     })
@@ -1029,7 +1029,7 @@ describe('test_campaigns_get', function () {
   request.path = '/v3/campaigns'
   request.headers['X-Mock'] = 200
   it('test_campaigns_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -1065,7 +1065,7 @@ describe('test_campaigns__campaign_id__patch', function () {
   request.path = '/v3/campaigns/{campaign_id}'
   request.headers['X-Mock'] = 200
   it('test_campaigns__campaign_id__patch had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -1092,7 +1092,7 @@ describe('test_campaigns__campaign_id__get', function () {
   request.path = '/v3/campaigns/{campaign_id}'
   request.headers['X-Mock'] = 200
   it('test_campaigns__campaign_id__get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -1120,7 +1120,7 @@ describe('test_campaigns__campaign_id__delete', function () {
   request.path = '/v3/campaigns/{campaign_id}'
   request.headers['X-Mock'] = 204
   it('test_campaigns__campaign_id__delete had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 204, 'response code is not correct')
       done();
     })
@@ -1150,7 +1150,7 @@ describe('test_campaigns__campaign_id__schedules_patch', function () {
   request.path = '/v3/campaigns/{campaign_id}/schedules'
   request.headers['X-Mock'] = 200
   it('test_campaigns__campaign_id__schedules_patch had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -1180,7 +1180,7 @@ describe('test_campaigns__campaign_id__schedules_post', function () {
   request.path = '/v3/campaigns/{campaign_id}/schedules'
   request.headers['X-Mock'] = 201
   it('test_campaigns__campaign_id__schedules_post had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 201, 'response code is not correct')
       done();
     })
@@ -1207,7 +1207,7 @@ describe('test_campaigns__campaign_id__schedules_get', function () {
   request.path = '/v3/campaigns/{campaign_id}/schedules'
   request.headers['X-Mock'] = 200
   it('test_campaigns__campaign_id__schedules_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -1235,7 +1235,7 @@ describe('test_campaigns__campaign_id__schedules_delete', function () {
   request.path = '/v3/campaigns/{campaign_id}/schedules'
   request.headers['X-Mock'] = 204
   it('test_campaigns__campaign_id__schedules_delete had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 204, 'response code is not correct')
       done();
     })
@@ -1263,7 +1263,7 @@ describe('test_campaigns__campaign_id__schedules_now_post', function () {
   request.path = '/v3/campaigns/{campaign_id}/schedules/now'
   request.headers['X-Mock'] = 201
   it('test_campaigns__campaign_id__schedules_now_post had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 201, 'response code is not correct')
       done();
     })
@@ -1293,7 +1293,7 @@ describe('test_campaigns__campaign_id__schedules_test_post', function () {
   request.path = '/v3/campaigns/{campaign_id}/schedules/test'
   request.headers['X-Mock'] = 204
   it('test_campaigns__campaign_id__schedules_test_post had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 204, 'response code is not correct')
       done();
     })
@@ -1324,7 +1324,7 @@ describe('test_categories_get', function () {
   request.path = '/v3/categories'
   request.headers['X-Mock'] = 200
   it('test_categories_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -1358,7 +1358,7 @@ describe('test_categories_stats_get', function () {
   request.path = '/v3/categories/stats'
   request.headers['X-Mock'] = 200
   it('test_categories_stats_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -1393,7 +1393,7 @@ describe('test_categories_stats_sums_get', function () {
   request.path = '/v3/categories/stats/sums'
   request.headers['X-Mock'] = 200
   it('test_categories_stats_sums_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -1424,7 +1424,7 @@ describe('test_clients_stats_get', function () {
   request.path = '/v3/clients/stats'
   request.headers['X-Mock'] = 200
   it('test_clients_stats_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -1455,7 +1455,7 @@ describe('test_clients__client_type__stats_get', function () {
   request.path = '/v3/clients/{client_type}/stats'
   request.headers['X-Mock'] = 200
   it('test_clients__client_type__stats_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -1486,7 +1486,7 @@ describe('test_contactdb_custom_fields_post', function () {
   request.path = '/v3/contactdb/custom_fields'
   request.headers['X-Mock'] = 201
   it('test_contactdb_custom_fields_post had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 201, 'response code is not correct')
       done();
     })
@@ -1513,7 +1513,7 @@ describe('test_contactdb_custom_fields_get', function () {
   request.path = '/v3/contactdb/custom_fields'
   request.headers['X-Mock'] = 200
   it('test_contactdb_custom_fields_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -1540,7 +1540,7 @@ describe('test_contactdb_custom_fields__custom_field_id__get', function () {
   request.path = '/v3/contactdb/custom_fields/{custom_field_id}'
   request.headers['X-Mock'] = 200
   it('test_contactdb_custom_fields__custom_field_id__get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -1568,7 +1568,7 @@ describe('test_contactdb_custom_fields__custom_field_id__delete', function () {
   request.path = '/v3/contactdb/custom_fields/{custom_field_id}'
   request.headers['X-Mock'] = 202
   it('test_contactdb_custom_fields__custom_field_id__delete had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 202, 'response code is not correct')
       done();
     })
@@ -1598,7 +1598,7 @@ describe('test_contactdb_lists_post', function () {
   request.path = '/v3/contactdb/lists'
   request.headers['X-Mock'] = 201
   it('test_contactdb_lists_post had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 201, 'response code is not correct')
       done();
     })
@@ -1625,7 +1625,7 @@ describe('test_contactdb_lists_get', function () {
   request.path = '/v3/contactdb/lists'
   request.headers['X-Mock'] = 200
   it('test_contactdb_lists_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -1658,7 +1658,7 @@ describe('test_contactdb_lists_delete', function () {
   request.path = '/v3/contactdb/lists'
   request.headers['X-Mock'] = 204
   it('test_contactdb_lists_delete had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 204, 'response code is not correct')
       done();
     })
@@ -1690,7 +1690,7 @@ describe('test_contactdb_lists__list_id__patch', function () {
   request.path = '/v3/contactdb/lists/{list_id}'
   request.headers['X-Mock'] = 200
   it('test_contactdb_lists__list_id__patch had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -1719,7 +1719,7 @@ describe('test_contactdb_lists__list_id__get', function () {
   request.path = '/v3/contactdb/lists/{list_id}'
   request.headers['X-Mock'] = 200
   it('test_contactdb_lists__list_id__get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -1749,7 +1749,7 @@ describe('test_contactdb_lists__list_id__delete', function () {
   request.path = '/v3/contactdb/lists/{list_id}'
   request.headers['X-Mock'] = 202
   it('test_contactdb_lists__list_id__delete had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 202, 'response code is not correct')
       done();
     })
@@ -1780,7 +1780,7 @@ describe('test_contactdb_lists__list_id__recipients_post', function () {
   request.path = '/v3/contactdb/lists/{list_id}/recipients'
   request.headers['X-Mock'] = 201
   it('test_contactdb_lists__list_id__recipients_post had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 201, 'response code is not correct')
       done();
     })
@@ -1811,7 +1811,7 @@ describe('test_contactdb_lists__list_id__recipients_get', function () {
   request.path = '/v3/contactdb/lists/{list_id}/recipients'
   request.headers['X-Mock'] = 200
   it('test_contactdb_lists__list_id__recipients_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -1839,7 +1839,7 @@ describe('test_contactdb_lists__list_id__recipients__recipient_id__post', functi
   request.path = '/v3/contactdb/lists/{list_id}/recipients/{recipient_id}'
   request.headers['X-Mock'] = 201
   it('test_contactdb_lists__list_id__recipients__recipient_id__post had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 201, 'response code is not correct')
       done();
     })
@@ -1870,7 +1870,7 @@ describe('test_contactdb_lists__list_id__recipients__recipient_id__delete', func
   request.path = '/v3/contactdb/lists/{list_id}/recipients/{recipient_id}'
   request.headers['X-Mock'] = 204
   it('test_contactdb_lists__list_id__recipients__recipient_id__delete had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 204, 'response code is not correct')
       done();
     })
@@ -1904,7 +1904,7 @@ describe('test_contactdb_recipients_patch', function () {
   request.path = '/v3/contactdb/recipients'
   request.headers['X-Mock'] = 201
   it('test_contactdb_recipients_patch had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 201, 'response code is not correct')
       done();
     })
@@ -1945,7 +1945,7 @@ describe('test_contactdb_recipients_post', function () {
   request.path = '/v3/contactdb/recipients'
   request.headers['X-Mock'] = 201
   it('test_contactdb_recipients_post had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 201, 'response code is not correct')
       done();
     })
@@ -1975,7 +1975,7 @@ describe('test_contactdb_recipients_get', function () {
   request.path = '/v3/contactdb/recipients'
   request.headers['X-Mock'] = 200
   it('test_contactdb_recipients_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -2006,7 +2006,7 @@ describe('test_contactdb_recipients_delete', function () {
   request.path = '/v3/contactdb/recipients'
   request.headers['X-Mock'] = 200
   it('test_contactdb_recipients_delete had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -2033,7 +2033,7 @@ describe('test_contactdb_recipients_billable_count_get', function () {
   request.path = '/v3/contactdb/recipients/billable_count'
   request.headers['X-Mock'] = 200
   it('test_contactdb_recipients_billable_count_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -2060,7 +2060,7 @@ describe('test_contactdb_recipients_count_get', function () {
   request.path = '/v3/contactdb/recipients/count'
   request.headers['X-Mock'] = 200
   it('test_contactdb_recipients_count_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -2090,7 +2090,7 @@ describe('test_contactdb_recipients_search_get', function () {
   request.path = '/v3/contactdb/recipients/search'
   request.headers['X-Mock'] = 200
   it('test_contactdb_recipients_search_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -2117,7 +2117,7 @@ describe('test_contactdb_recipients__recipient_id__get', function () {
   request.path = '/v3/contactdb/recipients/{recipient_id}'
   request.headers['X-Mock'] = 200
   it('test_contactdb_recipients__recipient_id__get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -2145,7 +2145,7 @@ describe('test_contactdb_recipients__recipient_id__delete', function () {
   request.path = '/v3/contactdb/recipients/{recipient_id}'
   request.headers['X-Mock'] = 204
   it('test_contactdb_recipients__recipient_id__delete had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 204, 'response code is not correct')
       done();
     })
@@ -2172,7 +2172,7 @@ describe('test_contactdb_recipients__recipient_id__lists_get', function () {
   request.path = '/v3/contactdb/recipients/{recipient_id}/lists'
   request.headers['X-Mock'] = 200
   it('test_contactdb_recipients__recipient_id__lists_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -2199,7 +2199,7 @@ describe('test_contactdb_reserved_fields_get', function () {
   request.path = '/v3/contactdb/reserved_fields'
   request.headers['X-Mock'] = 200
   it('test_contactdb_reserved_fields_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -2250,7 +2250,7 @@ describe('test_contactdb_segments_post', function () {
   request.path = '/v3/contactdb/segments'
   request.headers['X-Mock'] = 200
   it('test_contactdb_segments_post had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -2277,7 +2277,7 @@ describe('test_contactdb_segments_get', function () {
   request.path = '/v3/contactdb/segments'
   request.headers['X-Mock'] = 200
   it('test_contactdb_segments_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -2318,7 +2318,7 @@ describe('test_contactdb_segments__segment_id__patch', function () {
   request.path = '/v3/contactdb/segments/{segment_id}'
   request.headers['X-Mock'] = 200
   it('test_contactdb_segments__segment_id__patch had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -2347,7 +2347,7 @@ describe('test_contactdb_segments__segment_id__get', function () {
   request.path = '/v3/contactdb/segments/{segment_id}'
   request.headers['X-Mock'] = 200
   it('test_contactdb_segments__segment_id__get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -2377,7 +2377,7 @@ describe('test_contactdb_segments__segment_id__delete', function () {
   request.path = '/v3/contactdb/segments/{segment_id}'
   request.headers['X-Mock'] = 204
   it('test_contactdb_segments__segment_id__delete had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 204, 'response code is not correct')
       done();
     })
@@ -2407,7 +2407,7 @@ describe('test_contactdb_segments__segment_id__recipients_get', function () {
   request.path = '/v3/contactdb/segments/{segment_id}/recipients'
   request.headers['X-Mock'] = 200
   it('test_contactdb_segments__segment_id__recipients_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -2440,7 +2440,7 @@ describe('test_devices_stats_get', function () {
   request.path = '/v3/devices/stats'
   request.headers['X-Mock'] = 200
   it('test_devices_stats_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -2474,7 +2474,7 @@ describe('test_geo_stats_get', function () {
   request.path = '/v3/geo/stats'
   request.headers['X-Mock'] = 200
   it('test_geo_stats_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -2507,7 +2507,7 @@ describe('test_ips_get', function () {
   request.path = '/v3/ips'
   request.headers['X-Mock'] = 200
   it('test_ips_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -2534,7 +2534,7 @@ describe('test_ips_assigned_get', function () {
   request.path = '/v3/ips/assigned'
   request.headers['X-Mock'] = 200
   it('test_ips_assigned_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -2564,7 +2564,7 @@ describe('test_ips_pools_post', function () {
   request.path = '/v3/ips/pools'
   request.headers['X-Mock'] = 200
   it('test_ips_pools_post had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -2591,7 +2591,7 @@ describe('test_ips_pools_get', function () {
   request.path = '/v3/ips/pools'
   request.headers['X-Mock'] = 200
   it('test_ips_pools_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -2621,7 +2621,7 @@ describe('test_ips_pools__pool_name__put', function () {
   request.path = '/v3/ips/pools/{pool_name}'
   request.headers['X-Mock'] = 200
   it('test_ips_pools__pool_name__put had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -2648,7 +2648,7 @@ describe('test_ips_pools__pool_name__get', function () {
   request.path = '/v3/ips/pools/{pool_name}'
   request.headers['X-Mock'] = 200
   it('test_ips_pools__pool_name__get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -2676,7 +2676,7 @@ describe('test_ips_pools__pool_name__delete', function () {
   request.path = '/v3/ips/pools/{pool_name}'
   request.headers['X-Mock'] = 204
   it('test_ips_pools__pool_name__delete had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 204, 'response code is not correct')
       done();
     })
@@ -2706,7 +2706,7 @@ describe('test_ips_pools__pool_name__ips_post', function () {
   request.path = '/v3/ips/pools/{pool_name}/ips'
   request.headers['X-Mock'] = 201
   it('test_ips_pools__pool_name__ips_post had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 201, 'response code is not correct')
       done();
     })
@@ -2734,7 +2734,7 @@ describe('test_ips_pools__pool_name__ips__ip__delete', function () {
   request.path = '/v3/ips/pools/{pool_name}/ips/{ip}'
   request.headers['X-Mock'] = 204
   it('test_ips_pools__pool_name__ips__ip__delete had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 204, 'response code is not correct')
       done();
     })
@@ -2764,7 +2764,7 @@ describe('test_ips_warmup_post', function () {
   request.path = '/v3/ips/warmup'
   request.headers['X-Mock'] = 200
   it('test_ips_warmup_post had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -2791,7 +2791,7 @@ describe('test_ips_warmup_get', function () {
   request.path = '/v3/ips/warmup'
   request.headers['X-Mock'] = 200
   it('test_ips_warmup_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -2818,7 +2818,7 @@ describe('test_ips_warmup__ip_address__get', function () {
   request.path = '/v3/ips/warmup/{ip_address}'
   request.headers['X-Mock'] = 200
   it('test_ips_warmup__ip_address__get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -2846,7 +2846,7 @@ describe('test_ips_warmup__ip_address__delete', function () {
   request.path = '/v3/ips/warmup/{ip_address}'
   request.headers['X-Mock'] = 204
   it('test_ips_warmup__ip_address__delete had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 204, 'response code is not correct')
       done();
     })
@@ -2873,7 +2873,7 @@ describe('test_ips__ip_address__get', function () {
   request.path = '/v3/ips/{ip_address}'
   request.headers['X-Mock'] = 200
   it('test_ips__ip_address__get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -2901,7 +2901,7 @@ describe('test_mail_batch_post', function () {
   request.path = '/v3/mail/batch'
   request.headers['X-Mock'] = 201
   it('test_mail_batch_post had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 201, 'response code is not correct')
       done();
     })
@@ -2928,7 +2928,7 @@ describe('test_mail_batch__batch_id__get', function () {
   request.path = '/v3/mail/batch/{batch_id}'
   request.headers['X-Mock'] = 200
   it('test_mail_batch__batch_id__get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -3093,7 +3093,7 @@ describe('test_mail_send_post', function () {
   request.path = '/v3/mail/send'
   request.headers['X-Mock'] = 202
   it('test_mail_send_post had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 202, 'response code is not correct')
       done();
     })
@@ -3123,7 +3123,7 @@ describe('test_mail_settings_get', function () {
   request.path = '/v3/mail_settings'
   request.headers['X-Mock'] = 200
   it('test_mail_settings_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -3157,7 +3157,7 @@ describe('test_mail_settings_address_whitelist_patch', function () {
   request.path = '/v3/mail_settings/address_whitelist'
   request.headers['X-Mock'] = 200
   it('test_mail_settings_address_whitelist_patch had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -3184,7 +3184,7 @@ describe('test_mail_settings_address_whitelist_get', function () {
   request.path = '/v3/mail_settings/address_whitelist'
   request.headers['X-Mock'] = 200
   it('test_mail_settings_address_whitelist_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -3215,7 +3215,7 @@ describe('test_mail_settings_bcc_patch', function () {
   request.path = '/v3/mail_settings/bcc'
   request.headers['X-Mock'] = 200
   it('test_mail_settings_bcc_patch had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -3242,7 +3242,7 @@ describe('test_mail_settings_bcc_get', function () {
   request.path = '/v3/mail_settings/bcc'
   request.headers['X-Mock'] = 200
   it('test_mail_settings_bcc_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -3274,7 +3274,7 @@ describe('test_mail_settings_bounce_purge_patch', function () {
   request.path = '/v3/mail_settings/bounce_purge'
   request.headers['X-Mock'] = 200
   it('test_mail_settings_bounce_purge_patch had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -3301,7 +3301,7 @@ describe('test_mail_settings_bounce_purge_get', function () {
   request.path = '/v3/mail_settings/bounce_purge'
   request.headers['X-Mock'] = 200
   it('test_mail_settings_bounce_purge_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -3333,7 +3333,7 @@ describe('test_mail_settings_footer_patch', function () {
   request.path = '/v3/mail_settings/footer'
   request.headers['X-Mock'] = 200
   it('test_mail_settings_footer_patch had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -3360,7 +3360,7 @@ describe('test_mail_settings_footer_get', function () {
   request.path = '/v3/mail_settings/footer'
   request.headers['X-Mock'] = 200
   it('test_mail_settings_footer_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -3391,7 +3391,7 @@ describe('test_mail_settings_forward_bounce_patch', function () {
   request.path = '/v3/mail_settings/forward_bounce'
   request.headers['X-Mock'] = 200
   it('test_mail_settings_forward_bounce_patch had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -3418,7 +3418,7 @@ describe('test_mail_settings_forward_bounce_get', function () {
   request.path = '/v3/mail_settings/forward_bounce'
   request.headers['X-Mock'] = 200
   it('test_mail_settings_forward_bounce_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -3449,7 +3449,7 @@ describe('test_mail_settings_forward_spam_patch', function () {
   request.path = '/v3/mail_settings/forward_spam'
   request.headers['X-Mock'] = 200
   it('test_mail_settings_forward_spam_patch had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -3476,7 +3476,7 @@ describe('test_mail_settings_forward_spam_get', function () {
   request.path = '/v3/mail_settings/forward_spam'
   request.headers['X-Mock'] = 200
   it('test_mail_settings_forward_spam_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -3506,7 +3506,7 @@ describe('test_mail_settings_plain_content_patch', function () {
   request.path = '/v3/mail_settings/plain_content'
   request.headers['X-Mock'] = 200
   it('test_mail_settings_plain_content_patch had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -3533,7 +3533,7 @@ describe('test_mail_settings_plain_content_get', function () {
   request.path = '/v3/mail_settings/plain_content'
   request.headers['X-Mock'] = 200
   it('test_mail_settings_plain_content_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -3565,7 +3565,7 @@ describe('test_mail_settings_spam_check_patch', function () {
   request.path = '/v3/mail_settings/spam_check'
   request.headers['X-Mock'] = 200
   it('test_mail_settings_spam_check_patch had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -3592,7 +3592,7 @@ describe('test_mail_settings_spam_check_get', function () {
   request.path = '/v3/mail_settings/spam_check'
   request.headers['X-Mock'] = 200
   it('test_mail_settings_spam_check_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -3623,7 +3623,7 @@ describe('test_mail_settings_template_patch', function () {
   request.path = '/v3/mail_settings/template'
   request.headers['X-Mock'] = 200
   it('test_mail_settings_template_patch had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -3650,7 +3650,7 @@ describe('test_mail_settings_template_get', function () {
   request.path = '/v3/mail_settings/template'
   request.headers['X-Mock'] = 200
   it('test_mail_settings_template_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -3684,7 +3684,7 @@ describe('test_mailbox_providers_stats_get', function () {
   request.path = '/v3/mailbox_providers/stats'
   request.headers['X-Mock'] = 200
   it('test_mailbox_providers_stats_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -3714,7 +3714,7 @@ describe('test_partner_settings_get', function () {
   request.path = '/v3/partner_settings'
   request.headers['X-Mock'] = 200
   it('test_partner_settings_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -3746,7 +3746,7 @@ describe('test_partner_settings_new_relic_patch', function () {
   request.path = '/v3/partner_settings/new_relic'
   request.headers['X-Mock'] = 200
   it('test_partner_settings_new_relic_patch had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -3773,7 +3773,7 @@ describe('test_partner_settings_new_relic_get', function () {
   request.path = '/v3/partner_settings/new_relic'
   request.headers['X-Mock'] = 200
   it('test_partner_settings_new_relic_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -3800,7 +3800,7 @@ describe('test_scopes_get', function () {
   request.path = '/v3/scopes'
   request.headers['X-Mock'] = 200
   it('test_scopes_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -3833,7 +3833,7 @@ describe('test_stats_get', function () {
   request.path = '/v3/stats'
   request.headers['X-Mock'] = 200
   it('test_stats_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -3869,7 +3869,7 @@ describe('test_subusers_post', function () {
   request.path = '/v3/subusers'
   request.headers['X-Mock'] = 200
   it('test_subusers_post had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -3900,7 +3900,7 @@ describe('test_subusers_get', function () {
   request.path = '/v3/subusers'
   request.headers['X-Mock'] = 200
   it('test_subusers_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -3929,7 +3929,7 @@ describe('test_subusers_reputations_get', function () {
   request.path = '/v3/subusers/reputations'
   request.headers['X-Mock'] = 200
   it('test_subusers_reputations_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -3963,7 +3963,7 @@ describe('test_subusers_stats_get', function () {
   request.path = '/v3/subusers/stats'
   request.headers['X-Mock'] = 200
   it('test_subusers_stats_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -3997,7 +3997,7 @@ describe('test_subusers_stats_monthly_get', function () {
   request.path = '/v3/subusers/stats/monthly'
   request.headers['X-Mock'] = 200
   it('test_subusers_stats_monthly_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -4032,7 +4032,7 @@ describe('test_subusers_stats_sums_get', function () {
   request.path = '/v3/subusers/stats/sums'
   request.headers['X-Mock'] = 200
   it('test_subusers_stats_sums_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -4062,7 +4062,7 @@ describe('test_subusers__subuser_name__patch', function () {
   request.path = '/v3/subusers/{subuser_name}'
   request.headers['X-Mock'] = 204
   it('test_subusers__subuser_name__patch had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 204, 'response code is not correct')
       done();
     })
@@ -4090,7 +4090,7 @@ describe('test_subusers__subuser_name__delete', function () {
   request.path = '/v3/subusers/{subuser_name}'
   request.headers['X-Mock'] = 204
   it('test_subusers__subuser_name__delete had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 204, 'response code is not correct')
       done();
     })
@@ -4120,7 +4120,7 @@ describe('test_subusers__subuser_name__ips_put', function () {
   request.path = '/v3/subusers/{subuser_name}/ips'
   request.headers['X-Mock'] = 200
   it('test_subusers__subuser_name__ips_put had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -4151,7 +4151,7 @@ describe('test_subusers__subuser_name__monitor_put', function () {
   request.path = '/v3/subusers/{subuser_name}/monitor'
   request.headers['X-Mock'] = 200
   it('test_subusers__subuser_name__monitor_put had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -4182,7 +4182,7 @@ describe('test_subusers__subuser_name__monitor_post', function () {
   request.path = '/v3/subusers/{subuser_name}/monitor'
   request.headers['X-Mock'] = 200
   it('test_subusers__subuser_name__monitor_post had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -4209,7 +4209,7 @@ describe('test_subusers__subuser_name__monitor_get', function () {
   request.path = '/v3/subusers/{subuser_name}/monitor'
   request.headers['X-Mock'] = 200
   it('test_subusers__subuser_name__monitor_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -4237,7 +4237,7 @@ describe('test_subusers__subuser_name__monitor_delete', function () {
   request.path = '/v3/subusers/{subuser_name}/monitor'
   request.headers['X-Mock'] = 204
   it('test_subusers__subuser_name__monitor_delete had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 204, 'response code is not correct')
       done();
     })
@@ -4270,7 +4270,7 @@ describe('test_subusers__subuser_name__stats_monthly_get', function () {
   request.path = '/v3/subusers/{subuser_name}/stats/monthly'
   request.headers['X-Mock'] = 200
   it('test_subusers__subuser_name__stats_monthly_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -4302,7 +4302,7 @@ describe('test_suppression_blocks_get', function () {
   request.path = '/v3/suppression/blocks'
   request.headers['X-Mock'] = 200
   it('test_suppression_blocks_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -4336,7 +4336,7 @@ describe('test_suppression_blocks_delete', function () {
   request.path = '/v3/suppression/blocks'
   request.headers['X-Mock'] = 204
   it('test_suppression_blocks_delete had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 204, 'response code is not correct')
       done();
     })
@@ -4363,7 +4363,7 @@ describe('test_suppression_blocks__email__get', function () {
   request.path = '/v3/suppression/blocks/{email}'
   request.headers['X-Mock'] = 200
   it('test_suppression_blocks__email__get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -4391,7 +4391,7 @@ describe('test_suppression_blocks__email__delete', function () {
   request.path = '/v3/suppression/blocks/{email}'
   request.headers['X-Mock'] = 204
   it('test_suppression_blocks__email__delete had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 204, 'response code is not correct')
       done();
     })
@@ -4421,7 +4421,7 @@ describe('test_suppression_bounces_get', function () {
   request.path = '/v3/suppression/bounces'
   request.headers['X-Mock'] = 200
   it('test_suppression_bounces_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -4455,7 +4455,7 @@ describe('test_suppression_bounces_delete', function () {
   request.path = '/v3/suppression/bounces'
   request.headers['X-Mock'] = 204
   it('test_suppression_bounces_delete had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 204, 'response code is not correct')
       done();
     })
@@ -4482,7 +4482,7 @@ describe('test_suppression_bounces__email__get', function () {
   request.path = '/v3/suppression/bounces/{email}'
   request.headers['X-Mock'] = 200
   it('test_suppression_bounces__email__get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -4512,7 +4512,7 @@ describe('test_suppression_bounces__email__delete', function () {
   request.path = '/v3/suppression/bounces/{email}'
   request.headers['X-Mock'] = 204
   it('test_suppression_bounces__email__delete had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 204, 'response code is not correct')
       done();
     })
@@ -4544,7 +4544,7 @@ describe('test_suppression_invalid_emails_get', function () {
   request.path = '/v3/suppression/invalid_emails'
   request.headers['X-Mock'] = 200
   it('test_suppression_invalid_emails_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -4578,7 +4578,7 @@ describe('test_suppression_invalid_emails_delete', function () {
   request.path = '/v3/suppression/invalid_emails'
   request.headers['X-Mock'] = 204
   it('test_suppression_invalid_emails_delete had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 204, 'response code is not correct')
       done();
     })
@@ -4605,7 +4605,7 @@ describe('test_suppression_invalid_emails__email__get', function () {
   request.path = '/v3/suppression/invalid_emails/{email}'
   request.headers['X-Mock'] = 200
   it('test_suppression_invalid_emails__email__get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -4633,7 +4633,7 @@ describe('test_suppression_invalid_emails__email__delete', function () {
   request.path = '/v3/suppression/invalid_emails/{email}'
   request.headers['X-Mock'] = 204
   it('test_suppression_invalid_emails__email__delete had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 204, 'response code is not correct')
       done();
     })
@@ -4660,7 +4660,7 @@ describe('test_suppression_spam_report__email__get', function () {
   request.path = '/v3/suppression/spam_report/{email}'
   request.headers['X-Mock'] = 200
   it('test_suppression_spam_report__email__get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -4688,7 +4688,7 @@ describe('test_suppression_spam_report__email__delete', function () {
   request.path = '/v3/suppression/spam_report/{email}'
   request.headers['X-Mock'] = 204
   it('test_suppression_spam_report__email__delete had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 204, 'response code is not correct')
       done();
     })
@@ -4720,7 +4720,7 @@ describe('test_suppression_spam_reports_get', function () {
   request.path = '/v3/suppression/spam_reports'
   request.headers['X-Mock'] = 200
   it('test_suppression_spam_reports_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -4754,7 +4754,7 @@ describe('test_suppression_spam_reports_delete', function () {
   request.path = '/v3/suppression/spam_reports'
   request.headers['X-Mock'] = 204
   it('test_suppression_spam_reports_delete had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 204, 'response code is not correct')
       done();
     })
@@ -4786,7 +4786,7 @@ describe('test_suppression_unsubscribes_get', function () {
   request.path = '/v3/suppression/unsubscribes'
   request.headers['X-Mock'] = 200
   it('test_suppression_unsubscribes_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -4816,7 +4816,7 @@ describe('test_templates_post', function () {
   request.path = '/v3/templates'
   request.headers['X-Mock'] = 201
   it('test_templates_post had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 201, 'response code is not correct')
       done();
     })
@@ -4843,7 +4843,7 @@ describe('test_templates_get', function () {
   request.path = '/v3/templates'
   request.headers['X-Mock'] = 200
   it('test_templates_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -4873,7 +4873,7 @@ describe('test_templates__template_id__patch', function () {
   request.path = '/v3/templates/{template_id}'
   request.headers['X-Mock'] = 200
   it('test_templates__template_id__patch had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -4900,7 +4900,7 @@ describe('test_templates__template_id__get', function () {
   request.path = '/v3/templates/{template_id}'
   request.headers['X-Mock'] = 200
   it('test_templates__template_id__get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -4928,7 +4928,7 @@ describe('test_templates__template_id__delete', function () {
   request.path = '/v3/templates/{template_id}'
   request.headers['X-Mock'] = 204
   it('test_templates__template_id__delete had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 204, 'response code is not correct')
       done();
     })
@@ -4963,7 +4963,7 @@ describe('test_templates__template_id__versions_post', function () {
   request.path = '/v3/templates/{template_id}/versions'
   request.headers['X-Mock'] = 201
   it('test_templates__template_id__versions_post had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 201, 'response code is not correct')
       done();
     })
@@ -4997,7 +4997,7 @@ describe('test_templates__template_id__versions__version_id__patch', function ()
   request.path = '/v3/templates/{template_id}/versions/{version_id}'
   request.headers['X-Mock'] = 200
   it('test_templates__template_id__versions__version_id__patch had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -5024,7 +5024,7 @@ describe('test_templates__template_id__versions__version_id__get', function () {
   request.path = '/v3/templates/{template_id}/versions/{version_id}'
   request.headers['X-Mock'] = 200
   it('test_templates__template_id__versions__version_id__get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -5052,7 +5052,7 @@ describe('test_templates__template_id__versions__version_id__delete', function (
   request.path = '/v3/templates/{template_id}/versions/{version_id}'
   request.headers['X-Mock'] = 204
   it('test_templates__template_id__versions__version_id__delete had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 204, 'response code is not correct')
       done();
     })
@@ -5080,7 +5080,7 @@ describe('test_templates__template_id__versions__version_id__activate_post', fun
   request.path = '/v3/templates/{template_id}/versions/{version_id}/activate'
   request.headers['X-Mock'] = 200
   it('test_templates__template_id__versions__version_id__activate_post had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -5110,7 +5110,7 @@ describe('test_tracking_settings_get', function () {
   request.path = '/v3/tracking_settings'
   request.headers['X-Mock'] = 200
   it('test_tracking_settings_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -5140,7 +5140,7 @@ describe('test_tracking_settings_click_patch', function () {
   request.path = '/v3/tracking_settings/click'
   request.headers['X-Mock'] = 200
   it('test_tracking_settings_click_patch had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -5167,7 +5167,7 @@ describe('test_tracking_settings_click_get', function () {
   request.path = '/v3/tracking_settings/click'
   request.headers['X-Mock'] = 200
   it('test_tracking_settings_click_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -5202,7 +5202,7 @@ describe('test_tracking_settings_google_analytics_patch', function () {
   request.path = '/v3/tracking_settings/google_analytics'
   request.headers['X-Mock'] = 200
   it('test_tracking_settings_google_analytics_patch had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -5229,7 +5229,7 @@ describe('test_tracking_settings_google_analytics_get', function () {
   request.path = '/v3/tracking_settings/google_analytics'
   request.headers['X-Mock'] = 200
   it('test_tracking_settings_google_analytics_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -5259,7 +5259,7 @@ describe('test_tracking_settings_open_patch', function () {
   request.path = '/v3/tracking_settings/open'
   request.headers['X-Mock'] = 200
   it('test_tracking_settings_open_patch had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -5286,7 +5286,7 @@ describe('test_tracking_settings_open_get', function () {
   request.path = '/v3/tracking_settings/open'
   request.headers['X-Mock'] = 200
   it('test_tracking_settings_open_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -5321,7 +5321,7 @@ describe('test_tracking_settings_subscription_patch', function () {
   request.path = '/v3/tracking_settings/subscription'
   request.headers['X-Mock'] = 200
   it('test_tracking_settings_subscription_patch had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -5348,7 +5348,7 @@ describe('test_tracking_settings_subscription_get', function () {
   request.path = '/v3/tracking_settings/subscription'
   request.headers['X-Mock'] = 200
   it('test_tracking_settings_subscription_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -5375,7 +5375,7 @@ describe('test_user_account_get', function () {
   request.path = '/v3/user/account'
   request.headers['X-Mock'] = 200
   it('test_user_account_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -5402,7 +5402,7 @@ describe('test_user_credits_get', function () {
   request.path = '/v3/user/credits'
   request.headers['X-Mock'] = 200
   it('test_user_credits_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -5432,7 +5432,7 @@ describe('test_user_email_put', function () {
   request.path = '/v3/user/email'
   request.headers['X-Mock'] = 200
   it('test_user_email_put had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -5459,7 +5459,7 @@ describe('test_user_email_get', function () {
   request.path = '/v3/user/email'
   request.headers['X-Mock'] = 200
   it('test_user_email_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -5490,7 +5490,7 @@ describe('test_user_password_put', function () {
   request.path = '/v3/user/password'
   request.headers['X-Mock'] = 200
   it('test_user_password_put had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -5522,7 +5522,7 @@ describe('test_user_profile_patch', function () {
   request.path = '/v3/user/profile'
   request.headers['X-Mock'] = 200
   it('test_user_profile_patch had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -5549,7 +5549,7 @@ describe('test_user_profile_get', function () {
   request.path = '/v3/user/profile'
   request.headers['X-Mock'] = 200
   it('test_user_profile_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -5580,7 +5580,7 @@ describe('test_user_scheduled_sends_post', function () {
   request.path = '/v3/user/scheduled_sends'
   request.headers['X-Mock'] = 201
   it('test_user_scheduled_sends_post had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 201, 'response code is not correct')
       done();
     })
@@ -5607,7 +5607,7 @@ describe('test_user_scheduled_sends_get', function () {
   request.path = '/v3/user/scheduled_sends'
   request.headers['X-Mock'] = 200
   it('test_user_scheduled_sends_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -5637,7 +5637,7 @@ describe('test_user_scheduled_sends__batch_id__patch', function () {
   request.path = '/v3/user/scheduled_sends/{batch_id}'
   request.headers['X-Mock'] = 204
   it('test_user_scheduled_sends__batch_id__patch had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 204, 'response code is not correct')
       done();
     })
@@ -5664,7 +5664,7 @@ describe('test_user_scheduled_sends__batch_id__get', function () {
   request.path = '/v3/user/scheduled_sends/{batch_id}'
   request.headers['X-Mock'] = 200
   it('test_user_scheduled_sends__batch_id__get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -5692,7 +5692,7 @@ describe('test_user_scheduled_sends__batch_id__delete', function () {
   request.path = '/v3/user/scheduled_sends/{batch_id}'
   request.headers['X-Mock'] = 204
   it('test_user_scheduled_sends__batch_id__delete had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 204, 'response code is not correct')
       done();
     })
@@ -5723,7 +5723,7 @@ describe('test_user_settings_enforced_tls_patch', function () {
   request.path = '/v3/user/settings/enforced_tls'
   request.headers['X-Mock'] = 200
   it('test_user_settings_enforced_tls_patch had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -5750,7 +5750,7 @@ describe('test_user_settings_enforced_tls_get', function () {
   request.path = '/v3/user/settings/enforced_tls'
   request.headers['X-Mock'] = 200
   it('test_user_settings_enforced_tls_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -5780,7 +5780,7 @@ describe('test_user_username_put', function () {
   request.path = '/v3/user/username'
   request.headers['X-Mock'] = 200
   it('test_user_username_put had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -5807,7 +5807,7 @@ describe('test_user_username_get', function () {
   request.path = '/v3/user/username'
   request.headers['X-Mock'] = 200
   it('test_user_username_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -5849,7 +5849,7 @@ describe('test_user_webhooks_event_settings_patch', function () {
   request.path = '/v3/user/webhooks/event/settings'
   request.headers['X-Mock'] = 200
   it('test_user_webhooks_event_settings_patch had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -5876,7 +5876,7 @@ describe('test_user_webhooks_event_settings_get', function () {
   request.path = '/v3/user/webhooks/event/settings'
   request.headers['X-Mock'] = 200
   it('test_user_webhooks_event_settings_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -5906,7 +5906,7 @@ describe('test_user_webhooks_event_test_post', function () {
   request.path = '/v3/user/webhooks/event/test'
   request.headers['X-Mock'] = 204
   it('test_user_webhooks_event_test_post had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 204, 'response code is not correct')
       done();
     })
@@ -5939,7 +5939,7 @@ describe('test_user_webhooks_parse_settings_post', function () {
   request.path = '/v3/user/webhooks/parse/settings'
   request.headers['X-Mock'] = 201
   it('test_user_webhooks_parse_settings_post had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 201, 'response code is not correct')
       done();
     })
@@ -5966,7 +5966,7 @@ describe('test_user_webhooks_parse_settings_get', function () {
   request.path = '/v3/user/webhooks/parse/settings'
   request.headers['X-Mock'] = 200
   it('test_user_webhooks_parse_settings_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -5998,7 +5998,7 @@ describe('test_user_webhooks_parse_settings__hostname__patch', function () {
   request.path = '/v3/user/webhooks/parse/settings/{hostname}'
   request.headers['X-Mock'] = 200
   it('test_user_webhooks_parse_settings__hostname__patch had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -6025,7 +6025,7 @@ describe('test_user_webhooks_parse_settings__hostname__get', function () {
   request.path = '/v3/user/webhooks/parse/settings/{hostname}'
   request.headers['X-Mock'] = 200
   it('test_user_webhooks_parse_settings__hostname__get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -6053,7 +6053,7 @@ describe('test_user_webhooks_parse_settings__hostname__delete', function () {
   request.path = '/v3/user/webhooks/parse/settings/{hostname}'
   request.headers['X-Mock'] = 204
   it('test_user_webhooks_parse_settings__hostname__delete had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 204, 'response code is not correct')
       done();
     })
@@ -6086,7 +6086,7 @@ describe('test_user_webhooks_parse_stats_get', function () {
   request.path = '/v3/user/webhooks/parse/stats'
   request.headers['X-Mock'] = 200
   it('test_user_webhooks_parse_stats_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -6125,7 +6125,7 @@ describe('test_whitelabel_domains_post', function () {
   request.path = '/v3/whitelabel/domains'
   request.headers['X-Mock'] = 201
   it('test_whitelabel_domains_post had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 201, 'response code is not correct')
       done();
     })
@@ -6158,7 +6158,7 @@ describe('test_whitelabel_domains_get', function () {
   request.path = '/v3/whitelabel/domains'
   request.headers['X-Mock'] = 200
   it('test_whitelabel_domains_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -6185,7 +6185,7 @@ describe('test_whitelabel_domains_default_get', function () {
   request.path = '/v3/whitelabel/domains/default'
   request.headers['X-Mock'] = 200
   it('test_whitelabel_domains_default_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -6212,7 +6212,7 @@ describe('test_whitelabel_domains_subuser_get', function () {
   request.path = '/v3/whitelabel/domains/subuser'
   request.headers['X-Mock'] = 200
   it('test_whitelabel_domains_subuser_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -6240,7 +6240,7 @@ describe('test_whitelabel_domains_subuser_delete', function () {
   request.path = '/v3/whitelabel/domains/subuser'
   request.headers['X-Mock'] = 204
   it('test_whitelabel_domains_subuser_delete had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 204, 'response code is not correct')
       done();
     })
@@ -6271,7 +6271,7 @@ describe('test_whitelabel_domains__domain_id__patch', function () {
   request.path = '/v3/whitelabel/domains/{domain_id}'
   request.headers['X-Mock'] = 200
   it('test_whitelabel_domains__domain_id__patch had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -6298,7 +6298,7 @@ describe('test_whitelabel_domains__domain_id__get', function () {
   request.path = '/v3/whitelabel/domains/{domain_id}'
   request.headers['X-Mock'] = 200
   it('test_whitelabel_domains__domain_id__get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -6326,7 +6326,7 @@ describe('test_whitelabel_domains__domain_id__delete', function () {
   request.path = '/v3/whitelabel/domains/{domain_id}'
   request.headers['X-Mock'] = 204
   it('test_whitelabel_domains__domain_id__delete had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 204, 'response code is not correct')
       done();
     })
@@ -6356,7 +6356,7 @@ describe('test_whitelabel_domains__domain_id__subuser_post', function () {
   request.path = '/v3/whitelabel/domains/{domain_id}/subuser'
   request.headers['X-Mock'] = 201
   it('test_whitelabel_domains__domain_id__subuser_post had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 201, 'response code is not correct')
       done();
     })
@@ -6386,7 +6386,7 @@ describe('test_whitelabel_domains__id__ips_post', function () {
   request.path = '/v3/whitelabel/domains/{id}/ips'
   request.headers['X-Mock'] = 200
   it('test_whitelabel_domains__id__ips_post had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -6414,7 +6414,7 @@ describe('test_whitelabel_domains__id__ips__ip__delete', function () {
   request.path = '/v3/whitelabel/domains/{id}/ips/{ip}'
   request.headers['X-Mock'] = 200
   it('test_whitelabel_domains__id__ips__ip__delete had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -6442,7 +6442,7 @@ describe('test_whitelabel_domains__id__validate_post', function () {
   request.path = '/v3/whitelabel/domains/{id}/validate'
   request.headers['X-Mock'] = 200
   it('test_whitelabel_domains__id__validate_post had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -6474,7 +6474,7 @@ describe('test_whitelabel_ips_post', function () {
   request.path = '/v3/whitelabel/ips'
   request.headers['X-Mock'] = 201
   it('test_whitelabel_ips_post had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 201, 'response code is not correct')
       done();
     })
@@ -6505,7 +6505,7 @@ describe('test_whitelabel_ips_get', function () {
   request.path = '/v3/whitelabel/ips'
   request.headers['X-Mock'] = 200
   it('test_whitelabel_ips_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -6532,7 +6532,7 @@ describe('test_whitelabel_ips__id__get', function () {
   request.path = '/v3/whitelabel/ips/{id}'
   request.headers['X-Mock'] = 200
   it('test_whitelabel_ips__id__get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -6560,7 +6560,7 @@ describe('test_whitelabel_ips__id__delete', function () {
   request.path = '/v3/whitelabel/ips/{id}'
   request.headers['X-Mock'] = 204
   it('test_whitelabel_ips__id__delete had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 204, 'response code is not correct')
       done();
     })
@@ -6588,7 +6588,7 @@ describe('test_whitelabel_ips__id__validate_post', function () {
   request.path = '/v3/whitelabel/ips/{id}/validate'
   request.headers['X-Mock'] = 200
   it('test_whitelabel_ips__id__validate_post had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -6623,7 +6623,7 @@ describe('test_whitelabel_links_post', function () {
   request.path = '/v3/whitelabel/links'
   request.headers['X-Mock'] = 201
   it('test_whitelabel_links_post had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 201, 'response code is not correct')
       done();
     })
@@ -6652,7 +6652,7 @@ describe('test_whitelabel_links_get', function () {
   request.path = '/v3/whitelabel/links'
   request.headers['X-Mock'] = 200
   it('test_whitelabel_links_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -6681,7 +6681,7 @@ describe('test_whitelabel_links_default_get', function () {
   request.path = '/v3/whitelabel/links/default'
   request.headers['X-Mock'] = 200
   it('test_whitelabel_links_default_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -6710,7 +6710,7 @@ describe('test_whitelabel_links_subuser_get', function () {
   request.path = '/v3/whitelabel/links/subuser'
   request.headers['X-Mock'] = 200
   it('test_whitelabel_links_subuser_get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -6740,7 +6740,7 @@ describe('test_whitelabel_links_subuser_delete', function () {
   request.path = '/v3/whitelabel/links/subuser'
   request.headers['X-Mock'] = 204
   it('test_whitelabel_links_subuser_delete had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 204, 'response code is not correct')
       done();
     })
@@ -6770,7 +6770,7 @@ describe('test_whitelabel_links__id__patch', function () {
   request.path = '/v3/whitelabel/links/{id}'
   request.headers['X-Mock'] = 200
   it('test_whitelabel_links__id__patch had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -6797,7 +6797,7 @@ describe('test_whitelabel_links__id__get', function () {
   request.path = '/v3/whitelabel/links/{id}'
   request.headers['X-Mock'] = 200
   it('test_whitelabel_links__id__get had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -6825,7 +6825,7 @@ describe('test_whitelabel_links__id__delete', function () {
   request.path = '/v3/whitelabel/links/{id}'
   request.headers['X-Mock'] = 204
   it('test_whitelabel_links__id__delete had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 204, 'response code is not correct')
       done();
     })
@@ -6853,7 +6853,7 @@ describe('test_whitelabel_links__id__validate_post', function () {
   request.path = '/v3/whitelabel/links/{id}/validate'
   request.headers['X-Mock'] = 200
   it('test_whitelabel_links__id__validate_post had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })
@@ -6883,7 +6883,7 @@ describe('test_whitelabel_links__link_id__subuser_post', function () {
   request.path = '/v3/whitelabel/links/{link_id}/subuser'
   request.headers['X-Mock'] = 200
   it('test_whitelabel_links__link_id__subuser_post had the correct response code', function(done) {
-    sg.API(request, function (response) {
+    sg.API(request, function (error, response) {
       assert.equal(response.statusCode, 200, 'response code is not correct')
       done();
     })

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,5 @@
 var assert = require('chai').assert
+var sendgrid = require('../lib/sendgrid');
 
 describe('test_access_settings_activity_get', function () {
   this.timeout(30000);
@@ -9,7 +10,7 @@ describe('test_access_settings_activity_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -38,7 +39,7 @@ describe('test_access_settings_whitelist_post', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -78,7 +79,7 @@ describe('test_access_settings_whitelist_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -105,7 +106,7 @@ describe('test_access_settings_whitelist_delete', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -139,7 +140,7 @@ describe('test_access_settings_whitelist__rule_id__get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -166,7 +167,7 @@ describe('test_access_settings_whitelist__rule_id__delete', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -194,7 +195,7 @@ describe('test_alerts_post', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -226,7 +227,7 @@ describe('test_alerts_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -253,7 +254,7 @@ describe('test_alerts__alert_id__patch', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -283,7 +284,7 @@ describe('test_alerts__alert_id__get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -310,7 +311,7 @@ describe('test_alerts__alert_id__delete', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -338,7 +339,7 @@ describe('test_api_keys_post', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -374,7 +375,7 @@ describe('test_api_keys_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -403,7 +404,7 @@ describe('test_api_keys__api_key_id__put', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -437,7 +438,7 @@ describe('test_api_keys__api_key_id__patch', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -467,7 +468,7 @@ describe('test_api_keys__api_key_id__get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -494,7 +495,7 @@ describe('test_api_keys__api_key_id__delete', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -522,7 +523,7 @@ describe('test_asm_groups_post', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -554,7 +555,7 @@ describe('test_asm_groups_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -583,7 +584,7 @@ describe('test_asm_groups__group_id__patch', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -615,7 +616,7 @@ describe('test_asm_groups__group_id__get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -642,7 +643,7 @@ describe('test_asm_groups__group_id__delete', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -670,7 +671,7 @@ describe('test_asm_groups__group_id__suppressions_post', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -703,7 +704,7 @@ describe('test_asm_groups__group_id__suppressions_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -730,7 +731,7 @@ describe('test_asm_groups__group_id__suppressions_search_post', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -764,7 +765,7 @@ describe('test_asm_groups__group_id__suppressions__email__delete', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -792,7 +793,7 @@ describe('test_asm_suppressions_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -819,7 +820,7 @@ describe('test_asm_suppressions_global_post', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -852,7 +853,7 @@ describe('test_asm_suppressions_global__email__get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -879,7 +880,7 @@ describe('test_asm_suppressions_global__email__delete', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -907,7 +908,7 @@ describe('test_asm_suppressions__email__get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -934,7 +935,7 @@ describe('test_browsers_stats_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -968,7 +969,7 @@ describe('test_campaigns_post', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -1015,7 +1016,7 @@ describe('test_campaigns_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -1045,7 +1046,7 @@ describe('test_campaigns__campaign_id__patch', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -1081,7 +1082,7 @@ describe('test_campaigns__campaign_id__get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -1108,7 +1109,7 @@ describe('test_campaigns__campaign_id__delete', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -1136,7 +1137,7 @@ describe('test_campaigns__campaign_id__schedules_patch', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -1166,7 +1167,7 @@ describe('test_campaigns__campaign_id__schedules_post', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -1196,7 +1197,7 @@ describe('test_campaigns__campaign_id__schedules_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -1223,7 +1224,7 @@ describe('test_campaigns__campaign_id__schedules_delete', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -1251,7 +1252,7 @@ describe('test_campaigns__campaign_id__schedules_now_post', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -1279,7 +1280,7 @@ describe('test_campaigns__campaign_id__schedules_test_post', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -1309,7 +1310,7 @@ describe('test_categories_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -1340,7 +1341,7 @@ describe('test_categories_stats_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -1374,7 +1375,7 @@ describe('test_categories_stats_sums_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -1409,7 +1410,7 @@ describe('test_clients_stats_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -1440,7 +1441,7 @@ describe('test_clients__client_type__stats_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -1471,7 +1472,7 @@ describe('test_contactdb_custom_fields_post', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -1502,7 +1503,7 @@ describe('test_contactdb_custom_fields_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -1529,7 +1530,7 @@ describe('test_contactdb_custom_fields__custom_field_id__get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -1556,7 +1557,7 @@ describe('test_contactdb_custom_fields__custom_field_id__delete', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -1584,7 +1585,7 @@ describe('test_contactdb_lists_post', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -1614,7 +1615,7 @@ describe('test_contactdb_lists_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -1641,7 +1642,7 @@ describe('test_contactdb_lists_delete', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -1674,7 +1675,7 @@ describe('test_contactdb_lists__list_id__patch', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -1706,7 +1707,7 @@ describe('test_contactdb_lists__list_id__get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -1735,7 +1736,7 @@ describe('test_contactdb_lists__list_id__delete', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -1765,7 +1766,7 @@ describe('test_contactdb_lists__list_id__recipients_post', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -1796,7 +1797,7 @@ describe('test_contactdb_lists__list_id__recipients_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -1827,7 +1828,7 @@ describe('test_contactdb_lists__list_id__recipients__recipient_id__post', functi
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -1855,7 +1856,7 @@ describe('test_contactdb_lists__list_id__recipients__recipient_id__delete', func
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -1886,7 +1887,7 @@ describe('test_contactdb_recipients_patch', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -1920,7 +1921,7 @@ describe('test_contactdb_recipients_post', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -1961,7 +1962,7 @@ describe('test_contactdb_recipients_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -1991,7 +1992,7 @@ describe('test_contactdb_recipients_delete', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -2022,7 +2023,7 @@ describe('test_contactdb_recipients_billable_count_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -2049,7 +2050,7 @@ describe('test_contactdb_recipients_count_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -2076,7 +2077,7 @@ describe('test_contactdb_recipients_search_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -2106,7 +2107,7 @@ describe('test_contactdb_recipients__recipient_id__get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -2133,7 +2134,7 @@ describe('test_contactdb_recipients__recipient_id__delete', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -2161,7 +2162,7 @@ describe('test_contactdb_recipients__recipient_id__lists_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -2188,7 +2189,7 @@ describe('test_contactdb_reserved_fields_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -2215,7 +2216,7 @@ describe('test_contactdb_segments_post', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -2266,7 +2267,7 @@ describe('test_contactdb_segments_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -2293,7 +2294,7 @@ describe('test_contactdb_segments__segment_id__patch', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -2334,7 +2335,7 @@ describe('test_contactdb_segments__segment_id__get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -2363,7 +2364,7 @@ describe('test_contactdb_segments__segment_id__delete', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -2393,7 +2394,7 @@ describe('test_contactdb_segments__segment_id__recipients_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -2423,7 +2424,7 @@ describe('test_devices_stats_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -2456,7 +2457,7 @@ describe('test_geo_stats_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -2490,7 +2491,7 @@ describe('test_ips_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -2523,7 +2524,7 @@ describe('test_ips_assigned_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -2550,7 +2551,7 @@ describe('test_ips_pools_post', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -2580,7 +2581,7 @@ describe('test_ips_pools_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -2607,7 +2608,7 @@ describe('test_ips_pools__pool_name__put', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -2637,7 +2638,7 @@ describe('test_ips_pools__pool_name__get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -2664,7 +2665,7 @@ describe('test_ips_pools__pool_name__delete', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -2692,7 +2693,7 @@ describe('test_ips_pools__pool_name__ips_post', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -2722,7 +2723,7 @@ describe('test_ips_pools__pool_name__ips__ip__delete', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -2750,7 +2751,7 @@ describe('test_ips_warmup_post', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -2780,7 +2781,7 @@ describe('test_ips_warmup_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -2807,7 +2808,7 @@ describe('test_ips_warmup__ip_address__get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -2834,7 +2835,7 @@ describe('test_ips_warmup__ip_address__delete', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -2862,7 +2863,7 @@ describe('test_ips__ip_address__get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -2889,7 +2890,7 @@ describe('test_mail_batch_post', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -2917,7 +2918,7 @@ describe('test_mail_batch__batch_id__get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -2944,7 +2945,7 @@ describe('test_mail_send_post', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -3109,7 +3110,7 @@ describe('test_mail_settings_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -3139,7 +3140,7 @@ describe('test_mail_settings_address_whitelist_patch', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -3173,7 +3174,7 @@ describe('test_mail_settings_address_whitelist_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -3200,7 +3201,7 @@ describe('test_mail_settings_bcc_patch', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -3231,7 +3232,7 @@ describe('test_mail_settings_bcc_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -3258,7 +3259,7 @@ describe('test_mail_settings_bounce_purge_patch', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -3290,7 +3291,7 @@ describe('test_mail_settings_bounce_purge_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -3317,7 +3318,7 @@ describe('test_mail_settings_footer_patch', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -3349,7 +3350,7 @@ describe('test_mail_settings_footer_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -3376,7 +3377,7 @@ describe('test_mail_settings_forward_bounce_patch', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -3407,7 +3408,7 @@ describe('test_mail_settings_forward_bounce_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -3434,7 +3435,7 @@ describe('test_mail_settings_forward_spam_patch', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -3465,7 +3466,7 @@ describe('test_mail_settings_forward_spam_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -3492,7 +3493,7 @@ describe('test_mail_settings_plain_content_patch', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -3522,7 +3523,7 @@ describe('test_mail_settings_plain_content_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -3549,7 +3550,7 @@ describe('test_mail_settings_spam_check_patch', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -3581,7 +3582,7 @@ describe('test_mail_settings_spam_check_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -3608,7 +3609,7 @@ describe('test_mail_settings_template_patch', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -3639,7 +3640,7 @@ describe('test_mail_settings_template_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -3666,7 +3667,7 @@ describe('test_mailbox_providers_stats_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -3700,7 +3701,7 @@ describe('test_partner_settings_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -3730,7 +3731,7 @@ describe('test_partner_settings_new_relic_patch', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -3762,7 +3763,7 @@ describe('test_partner_settings_new_relic_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -3789,7 +3790,7 @@ describe('test_scopes_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -3816,7 +3817,7 @@ describe('test_stats_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -3849,7 +3850,7 @@ describe('test_subusers_post', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -3885,7 +3886,7 @@ describe('test_subusers_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -3916,7 +3917,7 @@ describe('test_subusers_reputations_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -3945,7 +3946,7 @@ describe('test_subusers_stats_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -3979,7 +3980,7 @@ describe('test_subusers_stats_monthly_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -4013,7 +4014,7 @@ describe('test_subusers_stats_sums_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -4048,7 +4049,7 @@ describe('test_subusers__subuser_name__patch', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -4078,7 +4079,7 @@ describe('test_subusers__subuser_name__delete', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -4106,7 +4107,7 @@ describe('test_subusers__subuser_name__ips_put', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -4136,7 +4137,7 @@ describe('test_subusers__subuser_name__monitor_put', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -4167,7 +4168,7 @@ describe('test_subusers__subuser_name__monitor_post', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -4198,7 +4199,7 @@ describe('test_subusers__subuser_name__monitor_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -4225,7 +4226,7 @@ describe('test_subusers__subuser_name__monitor_delete', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -4253,7 +4254,7 @@ describe('test_subusers__subuser_name__stats_monthly_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -4286,7 +4287,7 @@ describe('test_suppression_blocks_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -4318,7 +4319,7 @@ describe('test_suppression_blocks_delete', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -4352,7 +4353,7 @@ describe('test_suppression_blocks__email__get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -4379,7 +4380,7 @@ describe('test_suppression_blocks__email__delete', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -4407,7 +4408,7 @@ describe('test_suppression_bounces_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -4437,7 +4438,7 @@ describe('test_suppression_bounces_delete', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -4471,7 +4472,7 @@ describe('test_suppression_bounces__email__get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -4498,7 +4499,7 @@ describe('test_suppression_bounces__email__delete', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -4528,7 +4529,7 @@ describe('test_suppression_invalid_emails_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -4560,7 +4561,7 @@ describe('test_suppression_invalid_emails_delete', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -4594,7 +4595,7 @@ describe('test_suppression_invalid_emails__email__get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -4621,7 +4622,7 @@ describe('test_suppression_invalid_emails__email__delete', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -4649,7 +4650,7 @@ describe('test_suppression_spam_report__email__get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -4676,7 +4677,7 @@ describe('test_suppression_spam_report__email__delete', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -4704,7 +4705,7 @@ describe('test_suppression_spam_reports_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -4736,7 +4737,7 @@ describe('test_suppression_spam_reports_delete', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -4770,7 +4771,7 @@ describe('test_suppression_unsubscribes_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -4802,7 +4803,7 @@ describe('test_templates_post', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -4832,7 +4833,7 @@ describe('test_templates_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -4859,7 +4860,7 @@ describe('test_templates__template_id__patch', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -4889,7 +4890,7 @@ describe('test_templates__template_id__get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -4916,7 +4917,7 @@ describe('test_templates__template_id__delete', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -4944,7 +4945,7 @@ describe('test_templates__template_id__versions_post', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -4979,7 +4980,7 @@ describe('test_templates__template_id__versions__version_id__patch', function ()
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -5013,7 +5014,7 @@ describe('test_templates__template_id__versions__version_id__get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -5040,7 +5041,7 @@ describe('test_templates__template_id__versions__version_id__delete', function (
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -5068,7 +5069,7 @@ describe('test_templates__template_id__versions__version_id__activate_post', fun
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -5096,7 +5097,7 @@ describe('test_tracking_settings_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -5126,7 +5127,7 @@ describe('test_tracking_settings_click_patch', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -5156,7 +5157,7 @@ describe('test_tracking_settings_click_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -5183,7 +5184,7 @@ describe('test_tracking_settings_google_analytics_patch', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -5218,7 +5219,7 @@ describe('test_tracking_settings_google_analytics_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -5245,7 +5246,7 @@ describe('test_tracking_settings_open_patch', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -5275,7 +5276,7 @@ describe('test_tracking_settings_open_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -5302,7 +5303,7 @@ describe('test_tracking_settings_subscription_patch', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -5337,7 +5338,7 @@ describe('test_tracking_settings_subscription_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -5364,7 +5365,7 @@ describe('test_user_account_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -5391,7 +5392,7 @@ describe('test_user_credits_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -5418,7 +5419,7 @@ describe('test_user_email_put', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -5448,7 +5449,7 @@ describe('test_user_email_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -5475,7 +5476,7 @@ describe('test_user_password_put', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -5506,7 +5507,7 @@ describe('test_user_profile_patch', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -5538,7 +5539,7 @@ describe('test_user_profile_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -5565,7 +5566,7 @@ describe('test_user_scheduled_sends_post', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -5596,7 +5597,7 @@ describe('test_user_scheduled_sends_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -5623,7 +5624,7 @@ describe('test_user_scheduled_sends__batch_id__patch', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -5653,7 +5654,7 @@ describe('test_user_scheduled_sends__batch_id__get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -5680,7 +5681,7 @@ describe('test_user_scheduled_sends__batch_id__delete', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -5708,7 +5709,7 @@ describe('test_user_settings_enforced_tls_patch', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -5739,7 +5740,7 @@ describe('test_user_settings_enforced_tls_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -5766,7 +5767,7 @@ describe('test_user_username_put', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -5796,7 +5797,7 @@ describe('test_user_username_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -5823,7 +5824,7 @@ describe('test_user_webhooks_event_settings_patch', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -5865,7 +5866,7 @@ describe('test_user_webhooks_event_settings_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -5892,7 +5893,7 @@ describe('test_user_webhooks_event_test_post', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -5922,7 +5923,7 @@ describe('test_user_webhooks_parse_settings_post', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -5955,7 +5956,7 @@ describe('test_user_webhooks_parse_settings_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -5982,7 +5983,7 @@ describe('test_user_webhooks_parse_settings__hostname__patch', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -6014,7 +6015,7 @@ describe('test_user_webhooks_parse_settings__hostname__get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -6041,7 +6042,7 @@ describe('test_user_webhooks_parse_settings__hostname__delete', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -6069,7 +6070,7 @@ describe('test_user_webhooks_parse_stats_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -6102,7 +6103,7 @@ describe('test_whitelabel_domains_post', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -6141,7 +6142,7 @@ describe('test_whitelabel_domains_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -6174,7 +6175,7 @@ describe('test_whitelabel_domains_default_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -6201,7 +6202,7 @@ describe('test_whitelabel_domains_subuser_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -6228,7 +6229,7 @@ describe('test_whitelabel_domains_subuser_delete', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -6256,7 +6257,7 @@ describe('test_whitelabel_domains__domain_id__patch', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -6287,7 +6288,7 @@ describe('test_whitelabel_domains__domain_id__get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -6314,7 +6315,7 @@ describe('test_whitelabel_domains__domain_id__delete', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -6342,7 +6343,7 @@ describe('test_whitelabel_domains__domain_id__subuser_post', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -6372,7 +6373,7 @@ describe('test_whitelabel_domains__id__ips_post', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -6402,7 +6403,7 @@ describe('test_whitelabel_domains__id__ips__ip__delete', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -6430,7 +6431,7 @@ describe('test_whitelabel_domains__id__validate_post', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -6458,7 +6459,7 @@ describe('test_whitelabel_ips_post', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -6490,7 +6491,7 @@ describe('test_whitelabel_ips_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -6521,7 +6522,7 @@ describe('test_whitelabel_ips__id__get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -6548,7 +6549,7 @@ describe('test_whitelabel_ips__id__delete', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -6576,7 +6577,7 @@ describe('test_whitelabel_ips__id__validate_post', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -6604,7 +6605,7 @@ describe('test_whitelabel_links_post', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -6639,7 +6640,7 @@ describe('test_whitelabel_links_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -6668,7 +6669,7 @@ describe('test_whitelabel_links_default_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -6697,7 +6698,7 @@ describe('test_whitelabel_links_subuser_get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -6726,7 +6727,7 @@ describe('test_whitelabel_links_subuser_delete', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -6756,7 +6757,7 @@ describe('test_whitelabel_links__id__patch', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -6786,7 +6787,7 @@ describe('test_whitelabel_links__id__get', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -6813,7 +6814,7 @@ describe('test_whitelabel_links__id__delete', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -6841,7 +6842,7 @@ describe('test_whitelabel_links__id__validate_post', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -6869,7 +6870,7 @@ describe('test_whitelabel_links__link_id__subuser_post', function () {
     var TEST_HOST = 'localhost'
   }
 
-  var sg = require('../lib/sendgrid.js').SendGrid(API_KEY, TEST_HOST)
+  var sg = sendgrid(API_KEY, TEST_HOST)
 
   var request = sg.emptyRequest()
   if(TEST_HOST == 'localhost') {
@@ -6889,5 +6890,3 @@ describe('test_whitelabel_links__link_id__subuser_post', function () {
     })
   });
 })
-
-


### PR DESCRIPTION
This PR addresses the following issues:

- #240 
- #246 
- #206 

Notable changes:

- Extracted some logic into helpers
- Using a `getEmptyRequest` helper to avoid code duplication
- `emtpyRequest` now accepts an object with data to extend the empty request with, this will allow simpler syntax for initializing requests.
- Callback function now receives two parameters as per Node conventions (error, response)
- If no callback provided, the method will return a promise instead.
- Implemented promise API when not passing a callback function
- Using native Promise by default if present, but allow users to override this with any other implementation by setting `Sendgrid.Promise` to any value, e.g. `Sendgrid.Promise = require('bluebird')`

Example usage:

```js
let sendgrid = require('sendgrid');
sendgrid.SendGrid.Promise = require('bluebird');

let sg = sendgrid.SendGrid(process.env.SENDGRID_API_KEY);
let request = sg.emptyRequest({
  method: 'POST',
  path: '/v3/mail/send',
  body: mail.toJSON()
});

//Send request (returns promise)
sg.API(request)
  .then(response => ...)
  .catch(error => ...);

//Send request (using callback)
sg.API(request, (error, response) => {
  if (error) {
    //boo
  }
  //response always populated, even with error
});
```