### PR TITLE
Fill 'response' property in error instance

### DIFF
--- a/lib/sendgrid.js
+++ b/lib/sendgrid.js
@@ -111,6 +111,7 @@ SendGridInstance.prototype.API = function(request, callback) {
     }
     else {
       var error = new SendGridError('Response error');
+      error.response = response;
       callback(error, response);
     }
   });


### PR DESCRIPTION
This makes the behavior when using callbacks consistent with the promise counterpart.
That is, in both cases, `error.response` is present