### PR TITLE
feat: Add support for promises to the TypeScript definitions file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -466,6 +466,7 @@ declare namespace SendGrid {
         emptyRequest(): SendGrid.Rest.Request;
 
         API(request: SendGrid.Rest.Request, callback: (response: SendGrid.Rest.Response) => void): void;
+        API(request: SendGrid.Rest.Request): PromiseLike<SendGrid.Rest.Response>;
     }
 }
 


### PR DESCRIPTION
This should fix #307 by adding an overload definition for the `sg.API()` method which returns a promise when called without a second parameter (callback).