### PR TITLE
Drop 0.10, 0.12 from supported Node.js versions, add 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: node_js
 node_js:
-- "0.10"
-- "0.12"
 - "iojs"
 - "4"
+- "6"
 before_install:
 - npm install -g npm@2
 script:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ We welcome direct contributions to the sendgrid-nodejs code base. Thank you!
 
 ##### Prerequisites #####
 
-- Node.js version 0.10, 0.12 or 4
+- Node.js version 4 or 6
 - Please see [package.json](https://github.com/sendgrid/sendgrid-nodejs/tree/master/package.json)
 
 ##### Initial setup: #####

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ We appreciate your continued support, thank you!
 
 ## Prerequisites
 
-- Node.js version 0.10, 0.12 or 4
+- Node.js version 4 or 6
 - The SendGrid service, starting at the [free level](https://sendgrid.com/free?source=sendgrid-nodejs)
 
 ## Setup Environment Variables

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "git://github.com/sendgrid/sendgrid-nodejs.git"
   },
   "engines": {
-    "node": ">= 0.4.7"
+    "node": ">= 4.0.0"
   },
   "dependencies": {
     "async.ensureasync": "^0.5.2",


### PR DESCRIPTION
As discussed in #325 with @thinkingserious - PR to drop support for end-of-life Node.js v0.10 as of 01-Nov-2016. Also include Node.js LTS v6 in the list of supported versions, as all tests pass (using Prism).
