### PR TITLE
Add Inbound Parse data parser #303

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
 exports = module.exports = require('./lib/sendgrid');
 exports.mail = require('./lib/helpers/mail/mail.js');
 exports.importer = require('./lib/helpers/contact-importer/contact-importer.js');
+exports.parse = require('./lib/helpers/inbound/parse.js');

--- a/lib/helpers/inbound/parse.js
+++ b/lib/helpers/inbound/parse.js
@@ -2,7 +2,7 @@
 
 var fs = require('fs');
 var MailParser = require('mailparser').MailParser;
-var Attachment = require('../mail/mail').Attachment;
+var Attachment = require('../mail/mail.js').Attachment;
 
 /**
  * Normalises attachment files retrieved from file system or parsed raw email

--- a/lib/helpers/inbound/parse.js
+++ b/lib/helpers/inbound/parse.js
@@ -25,7 +25,7 @@ function createAttachment(file) {
  *
  * @constructor
  * @param {Object} config inbound configuration object
- * @param {Object} request The file object returned by file system or parsed email
+ * @param {Object} request request object of the parse webhook payload
  */
 function Parse(config, request) {
   this.keys = config.keys;

--- a/lib/helpers/inbound/parse.js
+++ b/lib/helpers/inbound/parse.js
@@ -22,6 +22,10 @@ function createAttachment(file) {
 
 /**
  * Simple class that parses data received from SendGrid Inbound Parse Webhook
+ *
+ * @constructor
+ * @param {Object} config inbound configuration object
+ * @param {Object} request The file object returned by file system or parsed email
  */
 function Parse(config, request) {
   this.keys = config.keys;

--- a/lib/helpers/inbound/parse.js
+++ b/lib/helpers/inbound/parse.js
@@ -1,0 +1,130 @@
+'use strict';
+
+var fs = require('fs');
+var MailParser = require('mailparser').MailParser;
+var Attachment = require('../mail/mail').Attachment;
+
+/**
+ * Normalises attachment files retrieved from file system or parsed raw email
+ *
+ * @param {Object} file The file object returned by file system or parsed email
+ * @return {Object} A SendGrid Attachment object with the file data
+ */
+function createAttachment(file) {
+  var attachment = new Attachment();
+
+  attachment.setFilename(file.originalname || file.fileName);
+  attachment.setType(file.mimetype || file.contentType);
+  attachment.setContent(file.content.toString('base64'));
+
+  return attachment;
+}
+
+/**
+ * Simple class that parses data received from SendGrid Inbound Parse Webhook
+ */
+function Parse(config, request) {
+  this.keys = config.keys;
+  this.request = request;
+  this.payload = request.body || {};
+  this.files = request.files || [];
+}
+
+/**
+ * Return an object literal of key/values in the payload received from webhook
+ * @return {Object} Valid key/values in the webhook payload
+ */
+Parse.prototype.keyValues = function() {
+  var keyValues = {};
+  var key;
+
+  for (var index in this.keys) {
+    key = this.keys[index];
+
+    if (this.payload[key]) {
+      keyValues[key] = this.payload[key];
+    }
+  }
+
+  return keyValues;
+};
+
+/**
+ * Whether the payload contains the raw email (Only applies to raw payloads)
+ * @return {Boolean}
+ */
+Parse.prototype.hasRawEmail = function() {
+  return Boolean(this.payload.email);
+};
+
+/**
+ * Parses the raw email and returns the mail object in a callback (Only applies to raw payloads)
+ * @param {Function} callback Function which will receive the parsed email object as the sole argument
+ */
+Parse.prototype.getRawEmail = function(callback) {
+  var mailparser = new MailParser();
+  var rawEmail = this.payload.email;
+
+  if (!rawEmail) {
+    return callback(null);
+  }
+
+  mailparser.on('end', callback);
+
+  mailparser.write(rawEmail);
+  mailparser.end();
+};
+
+/**
+ * Retrieves all attachments received from the webhook payload
+ * @param {Function} callback Function which will receive an array, of attachments found, as the sole argument
+ */
+Parse.prototype.attachments = function(callback) {
+  if (this.hasRawEmail()) {
+    return this._getAttachmentsRaw(callback);
+  }
+
+  this._getAttachments(callback);
+};
+
+/**
+ * Parses raw email to retrieve any encoded attachments (Only applies to raw payloads)
+ * @private
+ * @param {Function} callback Function which will receive an array, of attachments found, as the sole argument
+ */
+Parse.prototype._getAttachmentsRaw = function(callback) {
+  this.getRawEmail(function(parsedEmail) {
+    if (!parsedEmail || !parsedEmail.attachments) {
+      return callback([]);
+    }
+
+    var attachments = parsedEmail.attachments.map(function(file) {
+      return createAttachment(file);
+    });
+
+    callback(attachments);
+  });
+};
+
+/**
+ * Retrieves webhook payload files from the file system (Only applies to non raw payloads)
+ * @private
+ * @param {Function} callback Function which will receive an array, of attachments found, as the sole argument
+ */
+Parse.prototype._getAttachments = function(callback) {
+  var file;
+  var attachments = [];
+
+  for (var index in this.files) {
+    file = this.files[index];
+
+    if (fs.existsSync(file.path)) {
+      file.content = fs.readFileSync(file.path);
+      attachments.push(createAttachment(file));
+    }
+  }
+
+  return callback(attachments);
+};
+
+module.exports = Parse;

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "bottleneck": "^1.12.0",
     "debug": "^2.2.0",
     "lodash.chunk": "^4.2.0",
+    "mailparser": "^0.6.1",
     "sendgrid-rest": "^2.3.0"
   },
   "devDependencies": {

--- a/test/helpers/inbound/parse.test.js
+++ b/test/helpers/inbound/parse.test.js
@@ -1,0 +1,60 @@
+var Parse = require('../../../lib/helpers/inbound/parse.js');
+
+var expect = require('chai').expect;
+
+describe('test_parse', function() {
+  describe('test_parse_key_values', function() {
+    it('should return the key values specified in the config from the payload', function() {
+      var config = {
+        keys: ['to', 'from']
+      };
+      var request = {
+        body: {
+          to: 'inbound@inbound.example.com',
+          from: 'Test User <test@example.com>',
+          subject: 'Test Subject'
+        }
+      };
+
+      var parse = new Parse(config, request);
+      var keyValues = parse.keyValues();
+      var expectedValues = {
+        to: 'inbound@inbound.example.com',
+        from: 'Test User <test@example.com>'
+      };
+
+      expect(keyValues).to.be.an('object');
+      expect(keyValues).to.deep.equal(expectedValues);
+    })
+  })
+
+  describe('test_parse_get_raw_email', function() {
+    it('should return null if no raw email property in payload', function(done) {
+      var parse = new Parse({}, {});
+
+      function callback(email) {
+        expect(email).to.be.null;
+        done();
+      }
+
+      parse.getRawEmail(callback);
+    });
+
+    it('should parse raw email from payload and return a mail object', function(done) {
+      var request = {
+        body: {
+          email: 'MIME-Version: 1.0\r\nReceived: by 0.0.0.0 with HTTP; Wed, 10 Aug 2016 14:44:21 -0700 (PDT)\r\nFrom: Example User <test@example.com>\r\nDate: Wed, 10 Aug 2016 14:44:21 -0700\r\nSubject: Inbound Parse Test Raw Data\r\nTo: inbound@inbound.inbound.com\r\nContent-Type: multipart/alternative; boundary=001a113ee97c89842f0539be8e7a\r\n\r\n--001a113ee97c89842f0539be8e7a\r\nContent-Type: text/plain; charset=UTF-8\r\n\r\nHello SendGrid!\r\n\r\n--001a113ee97c89842f0539be8e7a\r\nContent-Type: text/html; charset=UTF-8\r\nContent-Transfer-Encoding: quoted-printable\r\n\r\n<html><body><strong>Hello SendGrid!</body></html>\r\n\r\n--001a113ee97c89842f0539be8e7a--\r\n'
+        }
+      };
+
+      var parse = new Parse({}, request);
+
+      function callback(email) {
+        expect(email).to.be.an('object');
+        done();
+      }
+
+      parse.getRawEmail(callback);
+    });
+  });
+});


### PR DESCRIPTION
An attempt of tackling issue #303. I've also pretty much done the bulk of the work around the Inbound Server Example and Send module, but will create separate PRs to make the reviewing easier.

Essentially my best effort of porting the python parse class to node (https://github.com/sendgrid/sendgrid-python/blob/master/sendgrid/helpers/inbound/parse.py)

**Changelog:**
- Adds [mailparser](https://www.npmjs.com/package/mailparser) npm dependency (required for parsing raw emails)
- Adds `parse.js` module
- Adds simple unit tests of the parse module

Example usage:

``` node
var Parse = require('sendgrid').parse;
var config = {
  keys: ['to', 'from', 'subject']
};

var parse = new Parse(config, request); 

// Get Key Values
console.log(parse.keyValues());

// Get Attachments
parse.attachments(function(attachments) {
  console.log(attachments)
});
```

NB: I've sent email with my signed CLA, awaiting confirmation
