### PR TITLE
[TypeDefinition] SendGrid.API should return Promise<T> instead of PromiseLike<T>

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -466,7 +466,7 @@ declare namespace SendGrid {
         emptyRequest(data?: SendGrid.Rest.Request): SendGrid.Rest.Request;
 
         API(request: SendGrid.Rest.Request, callback: (response: SendGrid.Rest.Response) => void): void;
-        API(request: SendGrid.Rest.Request): PromiseLike<SendGrid.Rest.Response>;
+        API(request: SendGrid.Rest.Request): Promise<SendGrid.Rest.Response>;
     }
 }
 


### PR DESCRIPTION
### Issue Summary

I think the [SendGrid.API](https://github.com/sendgrid/sendgrid-nodejs/blob/d01e7efb3a1f8f67435aec09ad633095ac322cc2/index.d.ts#L469) function should return a object on which either `.then()` or `.catch()` can be called upon.

The current implementation uses [PromiseLike<T>](https://github.com/Microsoft/TypeScript/tree/6814c1d883791a1ad976f3146315de30e00dc0b9/lib/lib.es6.d.ts#L1319) interface which only ensures `.then()`.
But the problem would be solved by using [Promise<T>](https://github.com/Microsoft/TypeScript/tree/6814c1d883791a1ad976f3146315de30e00dc0b9/lib/lib.es6.d.ts#L5221) interface instead.


#### Demo
```ts
SendGridClient
    .API(request)
    .then(okFunction)
    .catch(noOkFunction)  // this line will not be reported as an error anymore
```

#### Technical details:

* sendgrid-nodejs Version: master (latest commit: [https://github.com/sendgrid/sendgrid-nodejs/commit/d01e7ef])
* Node.js Version: 6.9.1
* TypeScript Version: 2.0.3

- - -
This references #308 
/cc @SPARTAN563 