### PR TITLE
Fix typescript definition for the ClickTracking

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -119,17 +119,17 @@ declare namespace SendGrid.Helpers.Mail {
     }
 
     export class ClickTracking {
-        constructor(enable: boolean, enableText: string);
+        constructor(enable: boolean, enableText: boolean);
 
         getEnable(): boolean;
         setEnable(enabled: boolean): void;
 
-        getEnableText(): string;
-        setEnableText(enableText: string): void;
+        getEnableText(): boolean;
+        setEnableText(enableText: boolean): void;
 
         toJSON(): {
             enable: boolean;
-            enable_text: string;
+            enable_text: boolean;
         };
     }
 


### PR DESCRIPTION
Small fix, the current definition in index.d.ts of ClickTracking right now is ClickTracking(boolean, string) this one is giving a error from the API, so it should be ClickTracking(boolean, boolean)