### PR TITLE
fix: Make various TypeScript request components optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -431,18 +431,18 @@ declare namespace SendGrid.Rest {
     export const emptyRequest: Request;
 
     interface Request {
-        host: string;
+        host?: string;
         method: "GET" | "PATCH" | "POST" | "PUT" | "DELETE";
         path: string;
-        headers: {
+        headers?: {
             [header: string]: string|number;
         };
-        body: string | {};
-        queryParams: {
+        body?: string | {};
+        queryParams?: {
             [param: string]: string;
         };
-        test: boolean;
-        port: string|number;
+        test?: boolean;
+        port?: string|number;
     }
 
     interface Response {


### PR DESCRIPTION
This should address the issues faced in #353 while still ensuring that we accurately cover the type's requirements.

Please let me know if you have any concerns or further requests for this fix.

Regards,
Benjamin

/cc @sheyaweidberg