### PR TITLE
Personalization.getSubstitutions() return type incorrect in index.d.ts TypeScript definition file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -406,7 +406,7 @@ declare namespace SendGrid.Helpers.Mail {
         getHeaders(): Header[];
 
         addSubstitution(substitution: Substitution): void;
-        getSubstitutions(): Substitution[];
+        getSubstitutions(): {[key: string]: string};
 
         addCustomArg(substitution: CustomArgs): void;
         getCustomArgs(): CustomArgs[];


### PR DESCRIPTION
Resolves #367.