### PR TITLE
Add a badge for `npm version`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![BuildStatus](https://travis-ci.org/sendgrid/sendgrid-nodejs.svg?branch=master)](https://travis-ci.org/sendgrid/sendgrid-nodejs)
+[![npm version](https://badge.fury.io/js/sendgrid.svg)](https://badge.fury.io/js/sendgrid)
 
 Please see our announcement regarding [breaking changes](https://github.com/sendgrid/sendgrid-nodejs/issues/290). Your support is appreciated!
 


### PR DESCRIPTION
The PR title describes the change in its entirety really. I am proposing adding a `npm version` badge to the top of the README file. This little informative badge allows people to click on it and easily jump to the npm listing (just like the Travis CI badge does already for code integration tests) and informs people about which version is actually up on npm. For those who do not care about either one of those benefits do not have to be worried - this little badge does not take up much space and is simply not in their way then.