### PR TITLE
Restructure README example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,21 +65,21 @@ The following is the minimum needed code to send an email with the [/mail/send H
 ### With Mail Helper Class
 
 ```javascript
-let helper = require('sendgrid').mail;
-let fromEmail = new helper.Email('test@example.com');
-let toEmail = new helper.Email('test@example.com');
-let subject = 'Hello World from the SendGrid Node.js Library!';
-let content = new helper.Content('text/plain', 'Hello, Email!');
-let mail = new helper.Mail(fromEmail, subject, toEmail, content);
+var helper = require('sendgrid').mail;
+var fromEmail = new helper.Email('test@example.com');
+var toEmail = new helper.Email('test@example.com');
+var subject = 'Hello World from the SendGrid Node.js Library!';
+var content = new helper.Content('text/plain', 'Hello, Email!');
+var mail = new helper.Mail(fromEmail, subject, toEmail, content);
 
-let sg = require('sendgrid')(process.env.SENDGRID_API_KEY);
-let request = sg.emptyRequest({
+var sg = require('sendgrid')(process.env.SENDGRID_API_KEY);
+var request = sg.emptyRequest({
   method: 'POST',
   path: '/v3/mail/send',
   body: mail.toJSON()
 });
 
-sg.API(request, (error, response) => {
+sg.API(request, function (error, response) {
   if (error) {
     console.log('Error response received');
   }
@@ -96,8 +96,8 @@ The `Mail` constructor creates a [personalization object](https://sendgrid.com/d
 The following is the minimum needed code to send an email without the /mail/send Helper ([here](https://github.com/sendgrid/sendgrid-nodejs/blob/master/examples/mail/mail.js#L31) is a full example):
 
 ```javascript
-let sg = require('sendgrid')(process.env.SENDGRID_API_KEY);
-let request = sg.emptyRequest({
+var sg = require('sendgrid')(process.env.SENDGRID_API_KEY);
+var request = sg.emptyRequest({
   method: 'POST',
   path: '/v3/mail/send',
   body: {
@@ -125,19 +125,19 @@ let request = sg.emptyRequest({
 
 // With promise
 sg.API(request)
-  .then(response => {
+  .then(function (response) {
     console.log(response.statusCode);
     console.log(response.body);
     console.log(response.headers);
   })
-  .catch(error => {
+  .catch(function (error) {
     // error is an instance of SendGridError
     // The full response is attached to error.response
     console.log(error.response.statusCode);
   });
 
 // With callback
-sg.API(request, (error, response) => {
+sg.API(request, function (error, response) {
   if (error) {
     console.log('Error response received');
   }
@@ -150,29 +150,29 @@ sg.API(request, (error, response) => {
 ## General v3 Web API Usage
 
 ```javascript
-let sg = require('sendgrid')(process.env.SENDGRID_API_KEY);
+var sg = require('sendgrid')(process.env.SENDGRID_API_KEY);
 
 // GET Collection
-let request = sg.emptyRequest({
+var request = sg.emptyRequest({
   method: 'GET',
   path: '/v3/api_keys'
 });
 
 // With promise
 sg.API(request)
-  .then(response => {
+  .then(function (response) {
     console.log(response.statusCode);
     console.log(response.body);
     console.log(response.headers);
   })
-  .catch(error => {
+  .catch(function (error) {
     // error is an instance of SendGridError
     // The full response is attached to error.response
     console.log(error.response.statusCode);
   });
 
 // With callback
-sg.API(request, (error, response) => {
+sg.API(request, function (error, response) {
   if (error) {
     console.log('Error response received');
   }

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ sg.API(request, function (error, response) {
 - [How-to: Migration from v2 to v3](https://sendgrid.com/docs/Classroom/Send/v3_Mail_Send/how_to_migrate_from_v2_to_v3_mail_send.html)
 - [v3 Web API Mail Send Helper](https://github.com/sendgrid/sendgrid-nodejs/tree/master/lib/helpers/mail/README.md)
 
-<a name="use_cases">
+<a name="use_cases"></a>
 # Use Cases
 
 [Examples of common API use cases](https://github.com/sendgrid/sendgrid-nodejs/blob/master/USE_CASES.md), such as how to send an email with a transactional template.
@@ -229,5 +229,4 @@ sendgrid-nodejs is guided and supported by the SendGrid [Developer Experience Te
 
 sendgrid-nodejs is maintained and funded by SendGrid, Inc. The names and logos for sendgrid-nodejs are trademarks of SendGrid, Inc.
 
-![SendGrid Logo]
-(https://uiux.s3.amazonaws.com/2016-logos/email-logo%402x.png)
+![SendGrid Logo](https://uiux.s3.amazonaws.com/2016-logos/email-logo%402x.png)

--- a/README.md
+++ b/README.md
@@ -66,20 +66,23 @@ The following is the minimum needed code to send an email with the [/mail/send H
 
 ```javascript
 var helper = require('sendgrid').mail;
-var from_email = new helper.Email('test@example.com');
-var to_email = new helper.Email('test@example.com');
+var fromEmail = new helper.Email('test@example.com');
+var toEmail = new helper.Email('test@example.com');
 var subject = 'Hello World from the SendGrid Node.js Library!';
 var content = new helper.Content('text/plain', 'Hello, Email!');
-var mail = new helper.Mail(from_email, subject, to_email, content);
+var mail = new helper.Mail(fromEmail, subject, toEmail, content);
 
 var sg = require('sendgrid')(process.env.SENDGRID_API_KEY);
 var request = sg.emptyRequest({
   method: 'POST',
   path: '/v3/mail/send',
-  body: mail.toJSON(),
+  body: mail.toJSON()
 });
 
-sg.API(request, function(error, response) {
+sg.API(request, function (error, response) {
+  if (error) {
+    console.log('Error response received');
+  }
   console.log(response.statusCode);
   console.log(response.body);
   console.log(response.headers);
@@ -102,25 +105,25 @@ var request = sg.emptyRequest({
       {
         to: [
           {
-            email: 'test@example.com',
-          },
+            email: 'test@example.com'
+          }
         ],
-        subject: 'Hello World from the SendGrid Node.js Library!',
-      },
+        subject: 'Hello World from the SendGrid Node.js Library!'
+      }
     ],
     from: {
-      email: 'test@example.com',
+      email: 'test@example.com'
     },
     content: [
       {
         type: 'text/plain',
-        value: 'Hello, Email!',
-      },
-    ],
-  },
+        value: 'Hello, Email!'
+      }
+    ]
+  }
 });
 
-//With promise
+// With promise
 sg.API(request)
   .then(response => {
     console.log(response.statusCode);
@@ -128,13 +131,13 @@ sg.API(request)
     console.log(response.headers);
   })
   .catch(error => {
-    //error is an instance of SendGridError
-    //The full response is attached to error.response
+    // error is an instance of SendGridError
+    // The full response is attached to error.response
     console.log(error.response.statusCode);
   });
 
-//With callback
-sg.API(request, function(error, response) {
+// With callback
+sg.API(request, function (error, response) {
   if (error) {
     console.log('Error response received');
   }
@@ -147,7 +150,7 @@ sg.API(request, function(error, response) {
 ## General v3 Web API Usage
 
 ```javascript
-var sg = require('sendgrid')(process.env.SENDGRID_API_KEY)
+var sg = require('sendgrid')(process.env.SENDGRID_API_KEY);
 
 // GET Collection
 var request = sg.emptyRequest({
@@ -155,28 +158,28 @@ var request = sg.emptyRequest({
   path: '/v3/api_keys'
 });
 
-//With promise
+// With promise
 sg.API(request)
   .then(response => {
-    console.log(response.statusCode)
-    console.log(response.body)
-    console.log(response.headers)
+    console.log(response.statusCode);
+    console.log(response.body);
+    console.log(response.headers);
   })
   .catch(error => {
-    //error is an instance of SendGridError
-    //The full response is attached to error.response
+    // error is an instance of SendGridError
+    // The full response is attached to error.response
     console.log(error.response.statusCode);
   });
 
-//With callback
-sg.API(request, function(error, response) {
+// With callback
+sg.API(request, function (error, response) {
   if (error) {
     console.log('Error response received');
   }
-  console.log(response.statusCode)
-  console.log(response.body)
-  console.log(response.headers)
-})
+  console.log(response.statusCode);
+  console.log(response.body);
+  console.log(response.headers);
+});
 ```
 
 <a name="usage"></a>

--- a/README.md
+++ b/README.md
@@ -65,21 +65,21 @@ The following is the minimum needed code to send an email with the [/mail/send H
 ### With Mail Helper Class
 
 ```javascript
-var helper = require('sendgrid').mail;
-var fromEmail = new helper.Email('test@example.com');
-var toEmail = new helper.Email('test@example.com');
-var subject = 'Hello World from the SendGrid Node.js Library!';
-var content = new helper.Content('text/plain', 'Hello, Email!');
-var mail = new helper.Mail(fromEmail, subject, toEmail, content);
+let helper = require('sendgrid').mail;
+let fromEmail = new helper.Email('test@example.com');
+let toEmail = new helper.Email('test@example.com');
+let subject = 'Hello World from the SendGrid Node.js Library!';
+let content = new helper.Content('text/plain', 'Hello, Email!');
+let mail = new helper.Mail(fromEmail, subject, toEmail, content);
 
-var sg = require('sendgrid')(process.env.SENDGRID_API_KEY);
-var request = sg.emptyRequest({
+let sg = require('sendgrid')(process.env.SENDGRID_API_KEY);
+let request = sg.emptyRequest({
   method: 'POST',
   path: '/v3/mail/send',
   body: mail.toJSON()
 });
 
-sg.API(request, function (error, response) {
+sg.API(request, (error, response) => {
   if (error) {
     console.log('Error response received');
   }
@@ -96,8 +96,8 @@ The `Mail` constructor creates a [personalization object](https://sendgrid.com/d
 The following is the minimum needed code to send an email without the /mail/send Helper ([here](https://github.com/sendgrid/sendgrid-nodejs/blob/master/examples/mail/mail.js#L31) is a full example):
 
 ```javascript
-var sg = require('sendgrid')(process.env.SENDGRID_API_KEY);
-var request = sg.emptyRequest({
+let sg = require('sendgrid')(process.env.SENDGRID_API_KEY);
+let request = sg.emptyRequest({
   method: 'POST',
   path: '/v3/mail/send',
   body: {
@@ -137,7 +137,7 @@ sg.API(request)
   });
 
 // With callback
-sg.API(request, function (error, response) {
+sg.API(request, (error, response) => {
   if (error) {
     console.log('Error response received');
   }
@@ -150,10 +150,10 @@ sg.API(request, function (error, response) {
 ## General v3 Web API Usage
 
 ```javascript
-var sg = require('sendgrid')(process.env.SENDGRID_API_KEY);
+let sg = require('sendgrid')(process.env.SENDGRID_API_KEY);
 
 // GET Collection
-var request = sg.emptyRequest({
+let request = sg.emptyRequest({
   method: 'GET',
   path: '/v3/api_keys'
 });
@@ -172,7 +172,7 @@ sg.API(request)
   });
 
 // With callback
-sg.API(request, function (error, response) {
+sg.API(request, (error, response) => {
   if (error) {
     console.log('Error response received');
   }


### PR DESCRIPTION
The proposed change:

- ~switches from `var` to `let` for cleaner scoping of variables.~
- ~switches all function expressions to arrow function expressions as to provide an easier overview.~
- removes trailing commas - although valid and arguably wildly used, not really a part of any standardization.
- adds semicolons where missing - mixing use of semicolons and avoiding them in the same codebase is not a good idea and since most of the examples do have semicolons after statements I am adding them where they were missing instead of removing the ones that were there but could be dropped.
- ensures comments start with a single space for consistency and readability.
- adds an error handling if clause to the first example.
- cleans up the source for displaying the logo as well as the _use cases_ header.

All of the changes, with the exception of the last bullet point, are for maintaining a consistent code style that people are welcome by when they visit the README. No actual changes in how the calls are made to the API/library are being introduced here.