### PR TITLE
Remove JSON.parse() around response bodies in contact-importer

### DIFF
--- a/lib/helpers/contact-importer/contact-importer.js
+++ b/lib/helpers/contact-importer/contact-importer.js
@@ -41,9 +41,9 @@ var ContactImporter = module.exports = function(sg, options) {
         owner: self,
       }, function(error, result) {
         if (error) {
-          return self._notify(error, JSON.parse(error.response.body), batch);
+          return self._notify(error, error.response.body, batch);
         }
-        return self._notify(null, JSON.parse(result.body), batch);
+        return self._notify(null, result.body, batch);
       });
     }
   };
@@ -79,9 +79,9 @@ ContactImporter.prototype.push = function(data) {
         owner: self,
       }, function(error, result) {
         if (error) {
-          return self._notify(error, JSON.parse(error.response.body), batch);
+          return self._notify(error, error.response.body, batch);
         }
-        return self._notify(null, JSON.parse(result.body), batch);
+        return self._notify(null, result.body, batch);
       });
     }
     // Otherwise, it store it for later.


### PR DESCRIPTION
Since 4.6.0, the `response.body` is a parsed object, rather than a JSON string. This fixes the contact-importer to not try to parse them itself, and allows its tests to pass again.