### PR TITLE
Return personalizations as an array of request compatible JSON.

### DIFF
--- a/lib/helpers/mail/mail.js
+++ b/lib/helpers/mail/mail.js
@@ -723,9 +723,11 @@ function Mail(from_email, subject, to_email, content) {
     }
     this.personalizations.push(personalization);
   };
-
+  // This array must be JSON compatible with the raw sendgrid request 
   this.getPersonalizations = function() {
-    return this.personalizations;
+    return this.personalizations.map(function(personalization) {
+       return personalization.toJSON();
+    });
   };
 
   this.setSubject = function(subject) {


### PR DESCRIPTION
There is a problem when you send a sendgrid request with model created by `helper.Mail` personalizations does not converter to JSON.

I fixed this.