### PR TITLE
Cast substitution values to strings

### DIFF
--- a/lib/helpers/mail/mail.js
+++ b/lib/helpers/mail/mail.js
@@ -622,8 +622,8 @@ function Personalization() {
     if (this.substitutions === undefined) {
       this.substitutions = {};
     }
-    this.substitutions[Object.keys(substitution)[0]] =
-      substitution[Object.keys(substitution)[0]];
+    var currentKey = Object.keys(substitution)[0];
+    this.substitutions[currentKey] = substitution[currentKey].toString();
   };
 
   this.getSubstitutions = function() {


### PR DESCRIPTION
This allows for numbers as well as strings for substitution values. Could still use some type checking and error handling to inform the user if they send an object (which also has a `toString` method, so won't throw) or other invalid value type.

Fixes #282.