### PR TITLE
Handle null and undefined values in substitutions

### DIFF
--- a/lib/helpers/mail/mail.js
+++ b/lib/helpers/mail/mail.js
@@ -623,7 +623,13 @@ function Personalization() {
       this.substitutions = {};
     }
     var currentKey = Object.keys(substitution)[0];
-    this.substitutions[currentKey] = substitution[currentKey].toString();
+    var currentVal = substitution[currentKey];
+    if (currentVal === null || typeof currentVal === 'undefined') {
+      this.substitutions[currentKey] = '';
+    }
+    else {
+      this.substitutions[currentKey] = currentVal.toString();
+    }
   };
 
   this.getSubstitutions = function() {


### PR DESCRIPTION
After #410 we started getting errors like `TypeError: Cannot read property 'toString' of null`. This tests for null or undefined values and handles them as empty string.