### PR TITLE
Export all type definitions in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,10 +1,11 @@
-declare namespace SendGrid.Helpers.Error {
+export declare namespace SendGrid.Helpers.Error {
     export interface SendGridError extends Error {
 
     }
 }
 
-declare namespace SendGrid.Helpers.Mail {
+
+export declare namespace SendGrid.Helpers.Mail {
     export interface Helper {
         Email: typeof Email;
         Mail: typeof Mail;
@@ -433,7 +434,7 @@ declare namespace SendGrid.Helpers.Mail {
     }
 }
 
-declare namespace SendGrid.Rest {
+export declare namespace SendGrid.Rest {
     export const emptyRequest: Request;
 
     interface Request {
@@ -458,7 +459,7 @@ declare namespace SendGrid.Rest {
     }
 }
 
-declare namespace SendGrid {
+export declare namespace SendGrid {
     export interface SendGridConstructor {
         (apiKey: string, host?: string, globalHeaders?: { [header: string]: string; }): SendGrid;
         constructor(apiKey: string, host?: string, globalHeaders?: { [header: string]: string; }): SendGrid;
@@ -470,11 +471,10 @@ declare namespace SendGrid {
         constructor(apiKey: string, host?: string, globalHeaders?: { [header: string]: string; });
 
         emptyRequest(data?: SendGrid.Rest.Request): SendGrid.Rest.Request;
-
         API(request: SendGrid.Rest.Request, callback: (err: SendGrid.Helpers.Error.SendGridError, response: SendGrid.Rest.Response) => void): void;
         API(request: SendGrid.Rest.Request): Promise<SendGrid.Rest.Response>;
     }
 }
 
 declare const sendGrid: SendGrid.SendGridConstructor;
-export = sendGrid;
+export default sendGrid;

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,7 +4,6 @@ export declare namespace SendGrid.Helpers.Error {
     }
 }
 
-
 export declare namespace SendGrid.Helpers.Mail {
     export interface Helper {
         Email: typeof Email;
@@ -471,6 +470,7 @@ export declare namespace SendGrid {
         constructor(apiKey: string, host?: string, globalHeaders?: { [header: string]: string; });
 
         emptyRequest(data?: SendGrid.Rest.Request): SendGrid.Rest.Request;
+
         API(request: SendGrid.Rest.Request, callback: (err: SendGrid.Helpers.Error.SendGridError, response: SendGrid.Rest.Response) => void): void;
         API(request: SendGrid.Rest.Request): Promise<SendGrid.Rest.Response>;
     }


### PR DESCRIPTION
It currently isn't possible to use SendGrid's types in a Typescript application as only the constructor is exported. For example, the following code does not work:

```typescript
import * as SendGrid from 'sendgrid';

const email: SendGrid.mail.Email = new SendGrid.mail.Email('test@test.com');
```

The type definition on `email` causes the typescript error: `[ts] Cannot find namespace 'SendGrid'.`

Exporting all of the namespaces allows users to explicitly declare types for variables using SendGrid's type definitions. Explicitly calling `export default` maintains compatibility while also giving access to SendGrids namespaces.