### PR TITLE
Prevent authorization header overwrite

### DIFF
--- a/packages/client/src/client.js
+++ b/packages/client/src/client.js
@@ -75,8 +75,8 @@ class Client {
     const headers = mergeData(this.defaultHeaders, data);
 
     //Add API key, but don't overwrite if header already set
-    if (typeof headers.Authorization === 'undefined' && this.apiKey) {
-      headers.Authorization = 'Bearer ' + this.apiKey;
+    if (typeof headers.authorization === 'undefined' && this.apiKey) {
+      headers.authorization = 'Bearer ' + this.apiKey;
     }
 
     //Return


### PR DESCRIPTION
The Mail object converts all keys to snake case so when you add an "Authorization" header it gets converted to "authorization". Thus the line I patched would never find an existing header.