### PR TITLE
Comma bug in name #448

### DIFF
--- a/packages/helpers/classes/email-address.js
+++ b/packages/helpers/classes/email-address.js
@@ -55,7 +55,9 @@ class EmailAddress {
     if (typeof name !== 'string') {
       throw new Error('String expected for `name`');
     }
-    this.name = name;
+    // Wrap name in quotes to address API issue
+    // https://github.com/sendgrid/sendgrid-csharp/issues/268#issuecomment-232177443
+    this.name = name.includes(',') ? `\"${name}\"` : name;
   }
 
   /**

--- a/packages/helpers/classes/email-address.js
+++ b/packages/helpers/classes/email-address.js
@@ -57,7 +57,9 @@ class EmailAddress {
     }
     // Wrap name in quotes to address API issue
     // https://github.com/sendgrid/sendgrid-csharp/issues/268#issuecomment-232177443
-    this.name = name.includes(',') ? `\"${name}\"` : name;
+    const isQuoted = (name[0] === '\"') && (name[name.length - 1] === '\"');
+    const shouldQuote = name.includes(',') && !isQuoted;
+    this.name = shouldQuote ? `\"${name}\"` : name;
   }
 
   /**

--- a/packages/helpers/classes/email-address.spec.js
+++ b/packages/helpers/classes/email-address.spec.js
@@ -59,6 +59,11 @@ describe('EmailAddress', function() {
       email.setName('Doe, John');
       expect(email.name).to.equal('\"Doe, John\"');
     });
+
+    it('should not double wrap in quotes', function() {
+      email.setName('\"Doe, John\"');
+      expect(email.name).to.equal('\"Doe, John\"');
+    });
     it('should throw an error for invalid input', function() {
       expect(function() {
         email.setName(5);

--- a/packages/helpers/classes/email-address.spec.js
+++ b/packages/helpers/classes/email-address.spec.js
@@ -54,6 +54,11 @@ describe('EmailAddress', function() {
       email.setName('Test');
       expect(email.name).to.equal('Test');
     });
+
+    it('should wrap name in quotes if a comma is present', function() {
+      email.setName('Doe, John');
+      expect(email.name).to.equal('\"Doe, John\"');
+    });
     it('should throw an error for invalid input', function() {
       expect(function() {
         email.setName(5);


### PR DESCRIPTION
Resolves #448 

- Wrap name in quotes if it contains a comma as suggested [here](https://github.com/sendgrid/sendgrid-csharp/issues/268#issuecomment-232177443)
- Add test cases