### PR TITLE
Update the license file to have the correct date range

### DIFF
--- a/packages/subscription-widget/LICENSE.txt
+++ b/packages/subscription-widget/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 SendGrid, Inc.
+Copyright (c) 2012-2017 SendGrid, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The main [LICENSE](https://github.com/lvarayut/sendgrid-nodejs/blob/4f73c88cd2800072835c63826a32aff898d9d444/LICENSE.md#L1) file has the correct year range. However, only the LICENSE file in the `subscription-widget` has the wrong range. This PR corrected it with the same year range specified in the main LICENSE file.

Fixed #562 