### PR TITLE
fix: Address an issue with the TypeScript definitions for TS2.6+

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "mocha-sinon": "^2.0.0",
     "sinon": "^2.3.2",
     "sinon-chai": "^2.10.0",
-    "typescript": "~2.4.2"
+    "typescript": "~2.6.1"
   },
   "scripts": {
     "lint": "eslint . --fix",

--- a/packages/client/src/client.d.ts
+++ b/packages/client/src/client.d.ts
@@ -34,4 +34,5 @@ declare class Client {
   request(data: ClientRequest, cb?: (err: ResponseError, response: [ClientResponse, any]) => void): Promise<[ClientResponse, any]>;
 }
 
-export = new Client()
+declare const client: Client;
+export = client;

--- a/packages/mail/src/mail.d.ts
+++ b/packages/mail/src/mail.d.ts
@@ -30,4 +30,5 @@ declare class MailService {
   sendMultiple(data: MailData, cb?: (error: Error|ResponseError, result: [ClientResponse, {}]) => void): Promise<[ClientResponse, {}]>;
 }
 
-export = new MailService()
+declare const mail: MailService;
+export = mail;


### PR DESCRIPTION
This PR addresses an issue raised by @ShaharHD in #476 which is caused by [TS2714](https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#arbitrary-expressions-are-forbidden-in-export-assignments-in-ambient-contexts) - specifically that the definition files may not make use of expressions as part of their `export = ` statements.

Instead, this PR updates the definitions to use the suggested pattern of:
```
const x: X
export = x
```
rather than:
```
export = new X()
```