### PR TITLE
Fixes TS7010 on tsConfigs with no implicit any

### DIFF
--- a/packages/helpers/classes/email-address.d.ts
+++ b/packages/helpers/classes/email-address.d.ts
@@ -8,17 +8,17 @@ export default class EmailAddress {
   /**
    * From data
    */
-  fromData(data: EmailData);
+  fromData(data: EmailData): void;
 
   /**
    * Set name
    */
-  setName(name: string);
+  setName(name: string): void;
 
   /**
    * Set email (mandatory)
    */
-  setEmail(email: string);
+  setEmail(email: string): void;
 
   toJSON(): EmailJSON;
 }


### PR DESCRIPTION
```
node_modules/@sendgrid/helpers/classes/email-address.d.ts(11,3): error TS7010: 'fromData', which lacks return-type annotation, implicitly has an 'any' return type.
node_modules/@sendgrid/helpers/classes/email-address.d.ts(16,3): error TS7010: 'setName', which lacks return-type annotation, implicitly has an 'any' return type.
node_modules/@sendgrid/helpers/classes/email-address.d.ts(21,3): error TS7010: 'setEmail', which lacks return-type annotation, implicitly has an 'any' return type.
```

This just updates the typings to fully declare what the function returns. When typescript is configured with noImplicitAny set to true, the errors above are triggered.

<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines given above, then fill out the blanks below.


Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g. 
Fixes #1
Closes #2
-->
# Fixes # 

### Checklist
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [ ] I have read the [Contribution Guide] and my PR follows them.
- [ ] I updated my branch with the master branch.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [ ] I have added in line documentation to the code I modified

### Short description of what this PR does:
- 
- 

If you have questions, please send an email to [Sendgrid](mailto:dx@sendgrid.com), or file a Github Issue in this repository.