### PR TITLE
v6.1.4 dependency of helpers fixed

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "6.1.3"
+  "version": "6.1.4"
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sendgrid/client",
   "description": "SendGrid NodeJS API client",
-  "version": "6.1.3",
+  "version": "6.1.4",
   "author": "SendGrid <dx@sendgrid.com> (sendgrid.com)",
   "contributors": [
     "Kyle Partridge <kyle.partridge@sendgrid.com>",

--- a/packages/inbound-mail-parser/package.json
+++ b/packages/inbound-mail-parser/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sendgrid/inbound-mail-parser",
   "description": "SendGrid NodeJS inbound mail parser",
-  "version": "6.1.3",
+  "version": "6.1.4",
   "author": "SendGrid <dx@sendgrid.com> (sendgrid.com)",
   "contributors": [
     "Kyle Partridge <kyle.partridge@sendgrid.com>",

--- a/packages/mail/package.json
+++ b/packages/mail/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sendgrid/mail",
   "description": "SendGrid NodeJS mail service",
-  "version": "6.1.3",
+  "version": "6.1.4",
   "author": "SendGrid <dx@sendgrid.com> (sendgrid.com)",
   "contributors": [
     "Kyle Partridge <kyle.partridge@sendgrid.com>",
@@ -27,7 +27,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@sendgrid/client": "^6.1.3",
+    "@sendgrid/client": "^6.1.4",
     "@sendgrid/helpers": "^6.1.3"
   },
   "tags": [


### PR DESCRIPTION
Fixes #667

### Checklist
- [*] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [*] I have read the [Contribution Guide] and my PR follows them.
- [*] I updated my branch with the master branch.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [ ] I have added in line documentation to the code I modified

### Short description of what this PR does:
- sticks the dependency of the @sendgrid/helpers to v6.1.3 and in @sendgrid/mail the @sendgrid/client to v6.1.4
