### PR TITLE
Bug in mail helper deleting dynamicTemplateData

### DIFF
--- a/packages/helpers/classes/mail.js
+++ b/packages/helpers/classes/mail.js
@@ -242,7 +242,7 @@ class Mail {
     //depending on the templateId
     if (this.isDynamic && personalization.substitutions) {
       delete personalization.substitutions;
-    } else if (personalization.dynamicTemplateData) {
+    } else if (!this.isDynamic && personalization.dynamicTemplateData) {
       delete personalization.dynamicTemplateData;
     }
 

--- a/packages/helpers/classes/personalization.d.ts
+++ b/packages/helpers/classes/personalization.d.ts
@@ -7,7 +7,7 @@ export interface PersonalizationData {
   subject?: string;
   headers?: { [key: string]: string };
   substitutions?: { [key: string]: string };
-  dynamicTemplateData?: { [key: string]: string; };
+  dynamicTemplateData?: { [key: string]: any; };
   customArgs?: { [key: string]: string };
   sendAt?: number;
 }
@@ -18,7 +18,7 @@ export interface PersonalizationJSON {
   bcc?: EmailJSON[];
   headers?: { [key: string]: string; };
   substitutions?: { [key: string]: string; };
-  dynamic_template_data?: { [key: string]: string; };
+  dynamic_template_data?: { [key: string]: any; };
   custom_args?: { [key: string]: string; };
   subject?: string;
   send_at?: number;


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines given above, then fill out the blanks below.


Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g. 
Fixes #1
Closes #2
-->
# Fixes # 

### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [ ] I have read the [Contribution Guide] and my PR follows them.
- [ ] I updated my branch with the master branch.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [ ] I have added in line documentation to the code I modified

### Short description of what this PR does:
- 
This line in mail helper is deleting `dynamicTemplateData` if `substitutions` is not set. I have also updated the types in personalization.d.ts to allow for non-string types in `dynamicTemplateData`
```
if (this.isDynamic && personalization.substitutions) {
      delete personalization.substitutions;
    } else if (personalization.dynamicTemplateData) {
      delete personalization.dynamicTemplateData;
    }
```
- 

If you have questions, please send an email to [Sendgrid](mailto:dx@sendgrid.com), or file a Github Issue in this repository.