### PR TITLE
Fix deepmerge require

### DIFF
--- a/packages/helpers/classes/personalization.js
+++ b/packages/helpers/classes/personalization.js
@@ -7,7 +7,7 @@ const EmailAddress = require('./email-address');
 const toCamelCase = require('../helpers/to-camel-case');
 const toSnakeCase = require('../helpers/to-snake-case');
 const deepClone = require('../helpers/deep-clone');
-const merge = require('deepmerge');
+const merge = require('deepmerge').default;
 const wrapSubstitutions = require('../helpers/wrap-substitutions');
 
 /**


### PR DESCRIPTION
Attempting to use the yet-to-be-documented `dynamicTemplateData` (instead of `substitutions`, which doesn’t work) results in:
> `merge is not a function` on [line 289](https://github.com/sendgrid/sendgrid-nodejs/blob/15d9b0a08c048ce41cf21d619fa16bbf2dd31550/packages/helpers/classes/personalization.js#L289)

This PR fixes the [deepmerge](https://github.com/KyleAMathews/deepmerge) require.