### PR TITLE
Fix subscription-widget node engine version

### DIFF
--- a/packages/subscription-widget/package.json
+++ b/packages/subscription-widget/package.json
@@ -21,6 +21,6 @@
     "access": "public"
   },
   "engines": {
-    "node": "4.1.1"
+    "node": ">=6.0.0"
   }
 }


### PR DESCRIPTION
### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.

If you execute `lerna bootstrap` it will try to install `subscription-widget` and it will fail:

```
lerna ERR! yarn install --mutex network:42424 --non-interactive stderr:
warning Waiting for the other yarn instance to finish (5655)
warning Waiting for the other yarn instance to finish (5674)
error @sendgrid/subscription-widget@6.2.1: The engine "node" is incompatible with this module. Expected version "4.1.1".
error Found incompatible module
```

This is due the node version being locked to a old version of node (`4.1.1`). This PR changes the node version to be compatible with all the other packages (`>=6.0.0`)