### PR TITLE
PR: #761 - Add automatic NPM publish via Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,17 @@ script:
 - yarn test:client
 - yarn test:helpers
 - yarn test:typescript
+before_deploy:
+  - echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" >> $HOME/.npmrc
+deploy:
+  provider: script
+  script: "npm run lerna:publish"
+  skip_cleanup: true
+  on:
+    node: "8"
+    tags: true
+    repo: sendgrid/sendgrid-nodejs
+    branch: master
 notifications:
   hipchat:
     rooms:

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "test:license": "babel-node ./node_modules/istanbul/lib/cli cover ./node_modules/mocha/bin/_mocha license.spec.js",
     "test:typescript": "tsc",
     "test": "npm run test:all -s",
-    "coverage": "open -a \"Google Chrome\" ./coverage/lcov-report/index.html"
+    "coverage": "open -a \"Google Chrome\" ./coverage/lcov-report/index.html",
+    "lerna:publish": "lerna publish from-git --yes"
   },
   "description": "![SendGrid Logo](https://uiux.s3.amazonaws.com/2016-logos/email-logo%402x.png)",
   "bugs": {


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines given above, then fill out the blanks below.


Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g. 
-->
# Resolves #761 # 

### Checklist
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [ ] I have added in line documentation to the code I modified

### Short description of what this PR does:
I added a Travis deploy config that uses `lerna publish` to automatically publish changed packages to NPM if a tagged commit was pushed on `master` branch (usually the result of running `lerna version`)

It creates a `.npmrc` in the `$HOME` folder so `lerna publish` knows where to publish the packages and which token to use. This is needed because the `npm publish` command is executed inside the `packages/foo` folder and we don't want to copy a `.npmrc` to every package folder. See https://github.com/lerna/lerna/issues/1705 for reference. ( Thanks @aslafy-z )

❗️ For this to work the environment variable `NPM_TOKEN` has to be set. An admin with publish rights for the `@sendgrid` scope at NPM has to generate a new auth token and run the following command to add the encrypted variable to the Travis config. This PR should only be merged if this happened.

```sh
travis encrypt NPM_TOKEN="<NPM_AUTH_TOKEN>" --add
```
See the [Travis CI Documentation](https://docs.travis-ci.com/user/encryption-keys/) for reference
