### PR TITLE
Warn if dynamic template contains non-escaped character

### DIFF
--- a/packages/helpers/classes/mail.js
+++ b/packages/helpers/classes/mail.js
@@ -9,6 +9,7 @@ const toCamelCase = require('../helpers/to-camel-case');
 const toSnakeCase = require('../helpers/to-snake-case');
 const deepClone = require('../helpers/deep-clone');
 const arrayToJSON = require('../helpers/array-to-json');
+const { DYNAMIC_TEMPLATE_CHAR_WARNING } = require('../constants');
 
 /**
  * Mail class
@@ -87,8 +88,9 @@ class Mail {
     this.setTrackingSettings(trackingSettings);
 
     if (this.isDynamic) {
-      this.setDynamicTemplateData(dynamicTemplateData)
-    } else {
+      this.setDynamicTemplateData(dynamicTemplateData);
+    }
+    else {
       this.setSubstitutions(substitutions);
       this.setSubstitutionWrappers(substitutionWrappers);
     }
@@ -242,7 +244,8 @@ class Mail {
     //depending on the templateId
     if (this.isDynamic && personalization.substitutions) {
       delete personalization.substitutions;
-    } else if (personalization.dynamicTemplateData) {
+    }
+    else if (personalization.dynamicTemplateData) {
       delete personalization.dynamicTemplateData;
     }
 
@@ -254,7 +257,8 @@ class Mail {
     //If this is dynamic, set dynamicTemplateData, or set substitutions
     if (this.isDynamic) {
       this.applyDynamicTemplateData(personalization);
-    } else {
+    }
+    else {
       this.applySubstitutions(personalization);
     }
 
@@ -333,6 +337,14 @@ class Mail {
     if (typeof dynamicTemplateData !== 'object') {
       throw new Error('Object expected for `dynamicTemplateData`');
     }
+
+    // Check dynamic template for non-escaped characters and warn if found
+    Object.values(dynamicTemplateData).forEach(value => {
+      if (/['"&]/.test(value)) {
+        console.warn(DYNAMIC_TEMPLATE_CHAR_WARNING);
+      }
+    });
+
     this.dynamicTemplateData = dynamicTemplateData;
   }
 

--- a/packages/helpers/classes/mail.spec.js
+++ b/packages/helpers/classes/mail.spec.js
@@ -4,6 +4,7 @@
  * Dependencies
  */
 const Mail = require('./mail');
+const { DYNAMIC_TEMPLATE_CHAR_WARNING } = require('../constants');
 
 /**
  * Tests
@@ -153,5 +154,64 @@ describe('Mail', function() {
       });
     });
 
+  });
+
+  describe('dynamic template handlebars substitutions', () => {
+    let logSpy, data;
+
+    beforeEach(() => {
+      logSpy = sinon.spy(console, 'warn');
+      data = {
+        to: 'recipient@example.org',
+        from: 'sender@example.org',
+        subject: 'Hello world',
+        text: 'Hello plain world!',
+        html: '<p>Hello HTML world!</p>',
+        templateId: 'd-df80613cccc6441ea5cd7c95377bc1ef',
+      };
+    });
+
+    afterEach(() => {
+      console.warn.restore();
+    });
+
+    it('should log an error if template subject line contains improperly escaped "\'" character', () => {
+      data = Object.assign(data, {
+        dynamicTemplateData: {
+          subject: 'Testing Templates and \'Stuff\'',
+        },
+      });
+
+      const mail = new Mail(data);
+
+      expect(logSpy.calledOnce).to.equal(true);
+      expect(logSpy.calledWith(DYNAMIC_TEMPLATE_CHAR_WARNING)).to.equal(true);
+    });
+
+    it('should log an error if template subject line contains improperly escaped """ character', () => {
+      data = Object.assign(data, {
+        dynamicTemplateData: {
+          subject: '"Testing Templates" and Stuff',
+        },
+      });
+
+      const mail = new Mail(data);
+
+      expect(logSpy.calledOnce).to.equal(true);
+      expect(logSpy.calledWith(DYNAMIC_TEMPLATE_CHAR_WARNING)).to.equal(true);
+    });
+
+    it('should log an error if template subject line contains improperly escaped "&" character', () => {
+      data = Object.assign(data, {
+        dynamicTemplateData: {
+          subject: 'Testing Templates & Stuff',
+        },
+      });
+
+      const mail = new Mail(data);
+
+      expect(logSpy.calledOnce).to.equal(true);
+      expect(logSpy.calledWith(DYNAMIC_TEMPLATE_CHAR_WARNING)).to.equal(true);
+    });
   });
 });

--- a/packages/helpers/constants/index.js
+++ b/packages/helpers/constants/index.js
@@ -1,0 +1,8 @@
+const DYNAMIC_TEMPLATE_CHAR_WARNING = `
+Content with characters ', " or & may need to be escaped with three brackets
+{{{ content }}}
+See https://sendgrid.com/docs/ui/sending-email/using-handlebars/ for more information.`;
+
+module.exports = {
+  DYNAMIC_TEMPLATE_CHAR_WARNING,
+};

--- a/use-cases/transactional-templates.md
+++ b/use-cases/transactional-templates.md
@@ -48,3 +48,54 @@ sgMail.send(msg);
 ```
 
 There's no need to specify the substitution wrappers as it will assume that you're using [Handlebars](https://handlebarsjs.com/) templating by default.
+
+## Prevent Escaping Characters
+
+Per Handlebars' documentation: If you don't want Handlebars to escape a value, use the "triple-stash", {{{
+
+> If you include the characters ', " or & in a subject line replacement be sure to use three brackets.
+
+Email Subject:
+
+```text
+{{{ subject }}}
+```
+
+Template Body:
+
+```html
+<html>
+<head>
+    <title></title>
+</head>
+<body>
+Hello {{{ name }}},
+<br /><br/>
+I'm glad you are trying out the template feature!
+<br /><br/>
+<%body%>
+<br /><br/>
+I hope you are having a great day in {{{ city }}} :)
+<br /><br/>
+</body>
+</html>
+```
+
+```js
+const sgMail = require('@sendgrid/mail');
+sgMail.setApiKey(process.env.SENDGRID_API_KEY);
+const msg = {
+  to: 'recipient@example.org',
+  from: 'sender@example.org',
+  subject: 'Hello world',
+  text: 'Hello plain world!',
+  html: '<p>Hello HTML world!</p>',
+  templateId: 'd-f43daeeaef504760851f727007e0b5d0',
+  dynamic_template_data: {
+    subject: 'Testing Templates & Stuff',
+    name: 'Some "Testing" One',
+    city: '<b>Denver<b>',
+  },
+};
+sgMail.send(msg);
+```


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines given above, then fill out the blanks below.


Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g. 
Fixes #1
Closes #2
-->
# Closes #790 

### Checklist
- [X] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [X] I have read the [Contribution Guide] and my PR follows them.
- [X] I updated my branch with the master branch.
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation about the functionality in the appropriate .md file
- [X] I have added in line documentation to the code I modified

### Short description of what this PR does:
- Warns if any of the ', " or & characters are used in a dynamic template that does not escape with triple-stash syntax

If you have questions, please send an email to [Sendgrid](mailto:dx@sendgrid.com), or file a Github Issue in this repository.