### PR TITLE
Update transactional-templates.md

### DIFF
--- a/use-cases/transactional-templates.md
+++ b/use-cases/transactional-templates.md
@@ -20,8 +20,6 @@ Hello {{ name }},
 <br /><br/>
 I'm glad you are trying out the template feature!
 <br /><br/>
-<%body%>
-<br /><br/>
 I hope you are having a great day in {{ city }} :)
 <br /><br/>
 </body>
@@ -34,9 +32,6 @@ sgMail.setApiKey(process.env.SENDGRID_API_KEY);
 const msg = {
   to: 'recipient@example.org',
   from: 'sender@example.org',
-  subject: 'Hello world',
-  text: 'Hello plain world!',
-  html: '<p>Hello HTML world!</p>',
   templateId: 'd-f43daeeaef504760851f727007e0b5d0',
   dynamic_template_data: {
     subject: 'Testing Templates',


### PR DESCRIPTION
There is no need for <%body%> in the email template as it does not work in dynamic templates. Also, the email send does not need a subject, text, or HTML section as those are all set in the template.
