### PR TITLE
Fix parser constructor error when passing payload

### DIFF
--- a/packages/inbound-mail-parser/src/parser.d.ts
+++ b/packages/inbound-mail-parser/src/parser.d.ts
@@ -6,6 +6,7 @@ declare interface ParseConfig {
 
 declare interface ParseRequest {
   body?: {};
+  payload?: {};
   files?: any[];
 }
 

--- a/packages/inbound-mail-parser/src/parser.js
+++ b/packages/inbound-mail-parser/src/parser.js
@@ -39,7 +39,7 @@ class Parse {
   constructor(config, request) {
     this.keys = config.keys;
     this.request = request;
-    this.payload = request.body || {};
+    this.payload = request.body || request.payload || {};
     this.files = request.files || [];
   }
 

--- a/packages/inbound-mail-parser/src/parser.spec.js
+++ b/packages/inbound-mail-parser/src/parser.spec.js
@@ -2,12 +2,35 @@ const Parse = require('./parser');
 
 describe('test_parse', () => {
   describe('test_parse_key_values', () => {
-    it('should return the key values specified in the config from the payload', () => {
+    it('should return the key values specified in the config from the body', () => {
       const config = {
         keys: ['to', 'from'],
       };
       const request = {
         body: {
+          to: 'inbound@inbound.example.com',
+          from: 'Test User <test@example.com>',
+          subject: 'Test Subject',
+        },
+      };
+
+      const parse = new Parse(config, request);
+      const keyValues = parse.keyValues();
+      const expectedValues = {
+        to: 'inbound@inbound.example.com',
+        from: 'Test User <test@example.com>',
+      };
+
+      expect(keyValues).to.be.an('object');
+      expect(keyValues).to.deep.equal(expectedValues);
+    });
+
+    it('should return the key values specified in the config from the payload', () => {
+      const config = {
+        keys: ['to', 'from'],
+      };
+      const request = {
+        payload: {
           to: 'inbound@inbound.example.com',
           from: 'Test User <test@example.com>',
           subject: 'Test Subject',


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines given above, then fill out the blanks below.


Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g. 
Fixes #1
Closes #2
-->
# Fixes #670

### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [ ] I have added in line documentation to the code I modified

### Short description of what this PR does:
- Fix parser constructor error when passing `payload` instead of `body`

If you have questions, please send an email to [Sendgrid](mailto:dx@sendgrid.com), or file a Github Issue in this repository.