### PR TITLE
Change object merge where crash while running newer node version

### DIFF
--- a/packages/helpers/classes/personalization.js
+++ b/packages/helpers/classes/personalization.js
@@ -286,7 +286,7 @@ class Personalization {
         'Object expected for `dynamicTemplateData` in deepMergeDynamicTemplateData'
       );
     }
-    this.dynamicTemplateData = merge(dynamicTemplateData, this.dynamicTemplateData);
+    this.dynamicTemplateData = Object.assign({}, dynamicTemplateData, this.dynamicTemplateData);
   }
 
   /**


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines given above, then fill out the blanks below.


Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g. 
Fixes #1
Closes #2
-->
# Fixes # 

### Checklist
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [ ] I have read the [Contribution Guide] and my PR follows them.
- [ ] I updated my branch with the master branch.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified

### Short description of what this PR does:
- Just was having issues while sending email where it would crash trying to merge the dynamic_template_data.
I change merge() to Object.assign() since it was used in other parts of the library I wasn't sure why this part used the merge() function.

If you have questions, please send an email to [Sendgrid](mailto:dx@sendgrid.com), or file a Github Issue in this repository.