### PR TITLE
Validate field types sent to mail helper API

### DIFF
--- a/packages/helpers/classes/mail.js
+++ b/packages/helpers/classes/mail.js
@@ -122,6 +122,9 @@ class Mail {
     if (typeof from === 'undefined') {
       return;
     }
+    if (typeof from !== 'string') {
+      throw new Error('String expected for `from`');
+    }
     this.from = EmailAddress.create(from);
   }
 
@@ -131,6 +134,9 @@ class Mail {
   setReplyTo(replyTo) {
     if (typeof replyTo === 'undefined') {
       return;
+    }
+    if (typeof replyTo !== 'string') {
+      throw new Error('String expected for `replyTo`');
     }
     this.replyTo = EmailAddress.create(replyTo);
   }
@@ -215,6 +221,13 @@ class Mail {
     if (typeof asm !== 'object') {
       throw new Error('Object expected for `asm`');
     }
+    if (typeof asm.group_id !== 'number') {
+      throw new Error('Expected `asm` to include an integer in its `group_id` field');
+    }
+    if (asm.groups_to_display &&
+      (!Array.isArray(asm.groups_to_display) || !asm.groups_to_display.every(group => typeof group === 'number'))) {
+      throw new Error('Array of integers expected for `asm.groups_to_display`');
+    }
     this.asm = asm;
   }
 
@@ -225,8 +238,9 @@ class Mail {
     if (typeof personalizations === 'undefined') {
       return;
     }
-    if (!Array.isArray(personalizations)) {
-      throw new Error('Array expected for `personalizations`');
+    if (!Array.isArray(personalizations) ||
+      !personalizations.every(personalization => typeof personalization === 'object')) {
+      throw new Error('Array of objects expected for `personalizations`');
     }
 
     //Clear and use add helper to add one by one
@@ -358,6 +372,18 @@ class Mail {
     if (!Array.isArray(content)) {
       throw new Error('Array expected for `content`');
     }
+    if (!content.every(contentField =>
+      typeof contentField === 'object')) {
+      throw new Error('Expected each entry in `content` to be an object');
+    }
+    if (!content.every(contentField =>
+      typeof contentField.type === 'string')) {
+      throw new Error('Expected each `content` entry to contain a `type` string');
+    }
+    if (!content.every(contentField =>
+      typeof contentField.value === 'string')) {
+      throw new Error('Expected each `content` entry to contain a `value` string');
+    }
     this.content = content;
   }
 
@@ -412,6 +438,22 @@ class Mail {
     }
     if (!Array.isArray(attachments)) {
       throw new Error('Array expected for `attachments`');
+    }
+    if (!attachments.every(attachment =>
+      typeof attachment.content === 'string')) {
+      throw new Error('Expected each attachment to contain a `content` string');
+    }
+    if (!attachments.every(attachment =>
+      typeof attachment.filename === 'string')) {
+      throw new Error('Expected each attachment to contain a `filename` string');
+    }
+    if (!attachments.every(attachment =>
+      attachment.type && typeof attachment.type === 'string')) {
+      throw new Error('Expected the attachment\'s `type` field to be a string');
+    }
+    if (!attachments.every(attachment =>
+      attachment.disposition && typeof attachment.disposition === 'string')) {
+      throw new Error('Expected the attachment\'s `disposition` field to be a string');
     }
     this.attachments = attachments;
   }

--- a/packages/helpers/classes/mail.js
+++ b/packages/helpers/classes/mail.js
@@ -10,6 +10,7 @@ const toSnakeCase = require('../helpers/to-snake-case');
 const deepClone = require('../helpers/deep-clone');
 const arrayToJSON = require('../helpers/array-to-json');
 const { DYNAMIC_TEMPLATE_CHAR_WARNING } = require('../constants');
+const {validateMailSettings, validateTrackingSettings} = require('../helpers/validate-settings');
 
 /**
  * Mail class
@@ -221,12 +222,12 @@ class Mail {
     if (typeof asm !== 'object') {
       throw new Error('Object expected for `asm`');
     }
-    if (typeof asm.group_id !== 'number') {
-      throw new Error('Expected `asm` to include an integer in its `group_id` field');
+    if (typeof asm.groupId !== 'number') {
+      throw new Error('Expected `asm` to include an integer in its `groupId` field');
     }
-    if (asm.groups_to_display &&
-      (!Array.isArray(asm.groups_to_display) || !asm.groups_to_display.every(group => typeof group === 'number'))) {
-      throw new Error('Array of integers expected for `asm.groups_to_display`');
+    if (asm.groupsToDisplay &&
+      (!Array.isArray(asm.groupsToDisplay) || !asm.groupsToDisplay.every(group => typeof group === 'number'))) {
+      throw new Error('Array of integers expected for `asm.groupsToDisplay`');
     }
     this.asm = asm;
   }
@@ -567,9 +568,7 @@ class Mail {
     if (typeof settings === 'undefined') {
       return;
     }
-    if (typeof settings !== 'object') {
-      throw new Error('Object expected for `mailSettings`');
-    }
+    validateMailSettings(settings);
     this.mailSettings = settings;
   }
 

--- a/packages/helpers/classes/mail.js
+++ b/packages/helpers/classes/mail.js
@@ -555,9 +555,7 @@ class Mail {
     if (typeof settings === 'undefined') {
       return;
     }
-    if (typeof settings !== 'object') {
-      throw new Error('Object expected for `trackingSettings`');
-    }
+    validateTrackingSettings(settings);
     this.trackingSettings = settings;
   }
 

--- a/packages/helpers/validate-settings.js
+++ b/packages/helpers/validate-settings.js
@@ -33,4 +33,29 @@ module.exports = {
     validate(spamCheck, 'spamCheck', 'postToUrl', 'string');
   },
 
+  validateTrackingSettings(settings) {
+    if (typeof settings !== 'object') {
+      throw new Error('Object expected for `mailSettings`');
+    }
+    const {
+      clickTracking,
+      openTracking,
+      subscriptionTracking,
+      ganalytics,
+    } = settings;
+    validate(clickTracking, 'clickTracking', 'enable', 'boolean');
+    validate(clickTracking, 'clickTracking', 'enableText', 'boolean');
+    validate(openTracking, 'openTracking', 'enable', 'boolean');
+    validate(openTracking, 'openTracking', 'substitutionTag', 'string');
+    validate(subscriptionTracking, 'subscriptionTracking', 'enable', 'boolean');
+    validate(subscriptionTracking, 'subscriptionTracking', 'text', 'string');
+    validate(subscriptionTracking, 'subscriptionTracking', 'html', 'string');
+    validate(subscriptionTracking, 'subscriptionTracking', 'substitutionTag', 'string');
+    validate(ganalytics, 'ganalytics', 'enable', 'boolean');
+    validate(ganalytics, 'ganalytics', 'utm_source', 'string');
+    validate(ganalytics, 'ganalytics', 'utm_medium', 'string');
+    validate(ganalytics, 'ganalytics', 'utm_term', 'string');
+    validate(ganalytics, 'ganalytics', 'utm_content', 'string');
+    validate(ganalytics, 'ganalytics', 'utm_campaign', 'string');
+  },
 };

--- a/packages/helpers/validate-settings.js
+++ b/packages/helpers/validate-settings.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const validate = (parent, parentName, childName, childType) => {
+  if (typeof parent === 'undefined' || typeof parent[childName] === 'undefined') {
+    return;
+  }
+  if (typeof parent[childName] !== childType) {
+    throw new Error(`${childType} expected for \`${parentName}.${childName}\``)
+  }
+};
+
+module.exports = {
+  validateMailSettings(settings) {
+    if (typeof settings !== 'object') {
+      throw new Error('Object expected for `mailSettings`');
+    }
+    const {
+      bcc,
+      bypassListManagement,
+      footer,
+      sandboxMode,
+      spamCheck,
+    } = settings;
+    validate(bcc, 'bcc', 'enable', 'boolean');
+    validate(bcc, 'bcc', 'email', 'string');
+    validate(bypassListManagement, 'bypassListManagement', 'enable', 'boolean');
+    validate(footer, 'footer', 'enable', 'boolean');
+    validate(footer, 'footer', 'text', 'string');
+    validate(footer, 'footer', 'html', 'string');
+    validate(sandboxMode, 'sandboxMode', 'enable', 'boolean');
+    validate(spamCheck, 'spamCheck', 'enable', 'boolean');
+    validate(spamCheck, 'spamCheck', 'threshold', 'number');
+    validate(spamCheck, 'spamCheck', 'postToUrl', 'string');
+  },
+
+};


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines given above, then fill out the blanks below.


Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g. 
Fixes #1
Closes #2
-->
# Fixes # 
Resolves #816 

### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified

### Short description of what this PR does:
Some of the fields from the [/mail/send POST API](https://sendgrid.com/docs/API_Reference/api_v3.html) supported by this library aren't typechecked before the request is sent. The change in this PR causes the library to throw an exception before sending the request if the types passed to it don't match the necessary types described in the API documentation.

If you have questions, please send an email to [Sendgrid](mailto:dx@sendgrid.com), or file a Github Issue in this repository.