### PR TITLE
docs: add more use cases for adding attachments

### DIFF
--- a/use-cases/attachments.md
+++ b/use-cases/attachments.md
@@ -21,3 +21,60 @@ const msg = {
   ],
 };
 ```
+Reading and converting a local PDF file. 
+```js
+import fs from 'fs';
+
+fs.readFile(('Document.pdf'), (err, data) => {
+  if (err) {
+    // do something with the error
+  }
+  if (data) {
+    const msg = {
+      to: 'recipient@test.org',
+      from: 'sender@test.org',
+      subject: 'Attachment',
+      html: '<p>Here’s an attachment for you!</p>',
+      attachments: [
+        {
+          content: data.toString('base64'),
+          filename: 'some-attachment.pdf',
+          type: 'application/pdf',
+          disposition: 'attachment',
+          contentId: 'mytext',
+        },
+      ],
+    };
+  }
+});
+  ```
+  
+  If you are using a PDF URL: 
+  ```js
+ import request from 'request';
+
+request(fileURl, { encoding: null }, (err, res, body) => {
+  if (err) { return err; }
+  if (body) {
+    const textBuffered = Buffer.from(body);
+
+    const msg = {
+      to: 'recipient@test.org',
+      from: 'sender@test.org',
+      subject: 'Attachment',
+      html: '<p>Here’s an attachment for you!</p>',
+      attachments: [
+        {
+          content: textBuffered.toString('base64'),
+          filename: 'some-attachment.pdf',
+          type: 'application/pdf',
+          disposition: 'attachment',
+          contentId: 'mytext',
+        },
+      ],
+    };
+    // send msg here
+  }
+});
+   ```
+  


### PR DESCRIPTION
Added use cases for adding attachments  and encode to base 64. From a local PDF file and using an URL (this example was tested using an AWS S3 bucket URL)

<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines given above, then fill out the blanks below.


Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g. 
Fixes #1
Closes #2
-->
# Fixes # 

### Checklist
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [ ] I have read the [Contribution Guide] and my PR follows them.
- [ ] I updated my branch with the master branch.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [x ] I have added inline documentation to the code I modified

### Short description of what this PR does:
- Added use cases for reading, encoding PDF. Also using an URL. 
- 

If you have questions, please send an email to [SendGrid](mailto:dx@sendgrid.com), or file a Github Issue in this repository.
