### PR TITLE
Dynamic template data and substitutions not appended to JSON

### DIFF
--- a/packages/helpers/classes/mail.js
+++ b/packages/helpers/classes/mail.js
@@ -575,9 +575,6 @@ class Mail {
     if (Object.keys(trackingSettings).length > 0) {
       json.trackingSettings = trackingSettings;
     }
-    if (substitutions && Object.keys(substitutions).length > 0) {
-      json.substitutions = substitutions;
-    }
     if (dynamicTemplateData && Object.keys(dynamicTemplateData).length > 0) {
       json.dynamicTemplateData = dynamicTemplateData;
     }

--- a/packages/helpers/classes/mail.js
+++ b/packages/helpers/classes/mail.js
@@ -165,6 +165,8 @@ class Mail {
    * Set template ID, also checks if the template is dynamic or legacy
    */
   setTemplateId(templateId) {
+    
+    //Validate
     if (typeof templateId === 'undefined') {
       return;
     }
@@ -172,10 +174,12 @@ class Mail {
       throw new Error('String expected for `templateId`');
     }
 
+    //Mark as dynamic if template ID starts with d-
     if (templateId.indexOf('d-') === 0) {
       this.isDynamic = true;
     }
-
+  
+    //Set ID
     this.templateId = templateId;
   }
 
@@ -541,7 +545,7 @@ class Mail {
       from, replyTo, sendAt, subject, content, templateId,
       personalizations, attachments, ipPoolName, batchId, asm,
       sections, headers, categories, customArgs, mailSettings,
-      trackingSettings,
+      trackingSettings, substitutions, dynamicTemplateData
     } = this;
 
     //Initialize with mandatory values
@@ -571,6 +575,12 @@ class Mail {
     if (Object.keys(trackingSettings).length > 0) {
       json.trackingSettings = trackingSettings;
     }
+    if (substitutions && Object.keys(substitutions).length > 0) {
+      json.substitutions = substitutions;
+    }
+    if (dynamicTemplateData && Object.keys(dynamicTemplateData).length > 0) {
+      json.dynamicTemplateData = dynamicTemplateData;
+    }
     if (Object.keys(customArgs).length > 0) {
       json.customArgs = customArgs;
     }
@@ -599,7 +609,10 @@ class Mail {
     }
 
     //Return as snake cased object
-    return toSnakeCase(json, ['substitutions', 'dynamicTemplateData', 'customArgs', 'headers', 'sections']);
+    return toSnakeCase(json, [
+      'substitutions', 'dynamicTemplateData', 
+      'customArgs', 'headers', 'sections',
+    ]);
   }
 
   /**************************************************************************

--- a/packages/helpers/classes/mail.js
+++ b/packages/helpers/classes/mail.js
@@ -545,7 +545,7 @@ class Mail {
       from, replyTo, sendAt, subject, content, templateId,
       personalizations, attachments, ipPoolName, batchId, asm,
       sections, headers, categories, customArgs, mailSettings,
-      trackingSettings, substitutions, dynamicTemplateData
+      trackingSettings, dynamicTemplateData
     } = this;
 
     //Initialize with mandatory values


### PR DESCRIPTION
This fixes dynamic template data and substitutions not getting appended to JSON requests.

### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the development branch.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [x] I have added in line documentation to the code I modified

### Short description of what this PR does:
I found that dynamic template data was not sent at all with any request, even if using a dynamic template ID. This PR fixes that and ensures the data is sent to the server.