### PR TITLE
fix: update MailService constructor property definition in TypeScript declaration

### DIFF
--- a/packages/mail/src/mail.d.ts
+++ b/packages/mail/src/mail.d.ts
@@ -30,5 +30,5 @@ declare class MailService {
   sendMultiple(data: MailData, cb?: (error: Error|ResponseError, result: [ClientResponse, {}]) => void): Promise<[ClientResponse, {}]>;
 }
 
-declare const mail: MailService & { MailService: MailService }
+declare const mail: MailService & { MailService: {new (): MailService} }
 export = mail

--- a/packages/mail/src/mail.d.ts
+++ b/packages/mail/src/mail.d.ts
@@ -30,5 +30,5 @@ declare class MailService {
   sendMultiple(data: MailData, cb?: (error: Error|ResponseError, result: [ClientResponse, {}]) => void): Promise<[ClientResponse, {}]>;
 }
 
-declare const mail: MailService & { MailService: {new (): MailService} }
+declare const mail: MailService & { MailService: typeof MailService }
 export = mail


### PR DESCRIPTION
Before, `{MailService: MailService}` suggested an instance of `MailService` was being passed. Changing the syntax to ~~`{new(): MailService}`~~ `typeof MailService` suggests that it's a callable constructor reference available as a property

<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines given above, then fill out the blanks below.


Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g. 
Fixes #1
Closes #2
-->
# Fixes # 

### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [ ] I updated my branch with the development branch.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [ ] I have added in line documentation to the code I modified

### Short description of what this PR does:
- 
- 

If you have questions, please send an email to [SendGrid](mailto:dx@sendgrid.com), or file a Github Issue in this repository.
