### PR TITLE
Fixed deepmerge module export naming issue

### DIFF
--- a/packages/helpers/classes/personalization.js
+++ b/packages/helpers/classes/personalization.js
@@ -7,7 +7,7 @@ const EmailAddress = require('./email-address');
 const toCamelCase = require('../helpers/to-camel-case');
 const toSnakeCase = require('../helpers/to-snake-case');
 const deepClone = require('../helpers/deep-clone');
-const deepmerge = require('deepmerge');
+const deepMerge = require('deepmerge');
 const wrapSubstitutions = require('../helpers/wrap-substitutions');
 
 /**
@@ -286,7 +286,7 @@ class Personalization {
         'Object expected for `dynamicTemplateData` in deepMergeDynamicTemplateData'
       );
     }
-    this.dynamicTemplateData = deepmerge(dynamicTemplateData, this.dynamicTemplateData);
+    this.dynamicTemplateData = deepMerge(dynamicTemplateData, this.dynamicTemplateData);
   }
 
   /**

--- a/packages/helpers/classes/personalization.js
+++ b/packages/helpers/classes/personalization.js
@@ -7,7 +7,7 @@ const EmailAddress = require('./email-address');
 const toCamelCase = require('../helpers/to-camel-case');
 const toSnakeCase = require('../helpers/to-snake-case');
 const deepClone = require('../helpers/deep-clone');
-const merge = require('deepmerge');
+const deepmerge = require('deepmerge');
 const wrapSubstitutions = require('../helpers/wrap-substitutions');
 
 /**
@@ -286,7 +286,7 @@ class Personalization {
         'Object expected for `dynamicTemplateData` in deepMergeDynamicTemplateData'
       );
     }
-    this.dynamicTemplateData = merge(dynamicTemplateData, this.dynamicTemplateData);
+    this.dynamicTemplateData = deepmerge(dynamicTemplateData, this.dynamicTemplateData);
   }
 
   /**


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines given above, then fill out the blanks below.

**All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g. 
Fixes #1
Closes #2
-->
Fixes #899  

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the development branch.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation about the functionality in the appropriate .md file
- [x] I have added in line documentation to the code I modified

### Short description of what this PR does:
This PR fixes webpack's interpolation issue with the deepmerge package. Related to the changes made to [deepmerge](https://github.com/TehShrike/deepmerge/pull/124). Renaming `merge` to `deepmerge` fixes the issue.

