### PR TITLE
Fix: options.uri must be string

### DIFF
--- a/packages/contact-importer/src/importer.js
+++ b/packages/contact-importer/src/importer.js
@@ -80,7 +80,7 @@ class ContactImporter extends EventEmitter {
 
     const request = {
       method: 'POST',
-      path: '/v3/contactdb/recipients',
+      uri: '/v3/contactdb/recipients',
       body: data,
     };
 


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines given above, then fill out the blanks below.

**All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g. 
Fixes #1
Closes #2
-->
# Fixes # 

### Checklist
- [X] I acknowledge that all my contributions will be made under the project's license
- [X] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [X] I have read the [Contribution Guide] and my PR follows them.
- [ ] I updated my branch with the development branch.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

### Short description of what this PR does:
- Fix issue with `request` package, it is looking for `URI` or `URL` when `baseUrl` is set, 

If you have questions, please send an email to [Twilio SendGrid](mailto:dx@sendgrid.com), or file a Github Issue in this repository.
