### PR TITLE
adds usage example for the @sendgrid/helpers EmailAddress class

### DIFF
--- a/packages/helpers/README.md
+++ b/packages/helpers/README.md
@@ -24,6 +24,39 @@ Used by the Mail class to compose `Personalization` objects.
 ## Email address
 `Helper` class to represent an email address with name/email. Used by both the `Mail` and `Personalization` classes to deal with email addresses of various formats.
 
+### Usage
+
+```javascript
+
+// ES5
+const sgHelpers = require('@sendgrid/helpers');
+const sgMail = require('@sendgrid/mail'); // NOT REQUIRED, JUST FOR ILLUSTRATION
+
+const msg = {
+  from: new sgHelpers.classes.EmailAddress({
+    name: _NAME OF THE SENDER_,
+    email: _EMAIL OF THE SENDER_
+   })
+}
+
+sgMail.send(msg)
+
+
+// ES6
+import { classes } from '@sendgrid/helpers';
+import sgMail from '@sendgrid/mail'; // NOT REQUIRED, JUST FOR ILLUSTRATION
+
+const msg = {
+  from: classes.EmailAddress({
+    name: _NAME OF THE SENDER_,
+    email: _EMAIL OF THE SENDER_
+  })
+}
+
+sgMail.send(msg);
+
+```
+
 ## Helpers
 Internal helpers that mostly speak for themselves.
 


### PR DESCRIPTION
## Description

I recently wanted to make use of the `EmailAddress` in the `@sendgrid/helpers` package but found that there was not usage example in the documentation. I had to read the code to figure out a way to use it.

Hence this PR, Will add more usage for other helper classes like `Personalization` etc. 

## Why raising the PR

- In case there is someone else who is just like me search the entire doc for an example of where the `Helper` classes are being used.

<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines given above, then fill out the blanks below.

**All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g. 
Fixes #1
Closes #2
-->
# Fixes # 

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [ ] I updated my branch with the development branch.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation about the functionality in the appropriate .md file
- [x] I have added in line documentation to the code I modified

If you have questions, please send an email to [Twilio SendGrid](mailto:dx@sendgrid.com), or file a Github Issue in this repository.
