### PR TITLE
fix: remove chai from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,8 +48,5 @@
   "directories": {
     "test": "test"
   },
-  "dependencies": {
-    "chai": "^4.0.1"
-  },
   "author": "Twilio SendGrid"
 }


### PR DESCRIPTION
chai is only needed as a development dependency.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
