### PR TITLE
fix #1027: Move @types/request back to dependencies

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -28,10 +28,8 @@
   },
   "dependencies": {
     "@sendgrid/helpers": "^6.5.1",
+    "@types/request": "^2.48.4",
     "request": "^2.88.0"
-  },
-  "devDependencies": {
-    "@types/request": "^2.0.3"
   },
   "tags": [
     "http",


### PR DESCRIPTION
Fixes #1027. 

This moves the `@types/request` dependency back into the non-dev category, unbreaking the package for TypeScript users. This is described as best practice here:

https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#dependencies

I also bumped the version up from 2.0.4, which was [two years old](https://www.npmjs.com/package/@types/request), to 2.48.4. I am unsure how DefinitelyTyped versions their types packages... but request v2.88.0 is the most recent version on NPM, so I assume y'all want the latest @types/request version also.