### PR TITLE
fix: update node version in travis for deploy via lerna

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: node_js
+node_js:
+  - 10
 env:
   - version=6
   - version=7

--- a/lerna.json
+++ b/lerna.json
@@ -3,6 +3,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "7.1.1",
-  "tagVersionPrefix": ""
+  "tagVersionPrefix": "",
+  "lerna": "2.0.0"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -3,6 +3,7 @@
   "packages": [
     "packages/*"
   ],
+  "version": "7.1.1",
   "tagVersionPrefix": "",
   "lerna": "2.0.0"
 }


### PR DESCRIPTION
Updating from node v0.10.48 to v10.20.1 since `lerna` requires node >= v6.9.0.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license