### PR TITLE
docs: Fixing sandbox key in kitchen-sink documentation

### DIFF
--- a/docs/use-cases/kitchen-sink.md
+++ b/docs/use-cases/kitchen-sink.md
@@ -41,7 +41,7 @@ const msg = {
   },
   ipPoolName: 'sendgrid-ip-pool-name',
   mailSettings: {
-    sandbox: {
+    sandboxMode: {
       enable: true,
     },
   },


### PR DESCRIPTION
The documentation in [kitchen-sink.md](https://github.com/sendgrid/sendgrid-nodejs/blob/master/docs/use-cases/kitchen-sink.md) has a typo. According to the [mail](https://github.com/sendgrid/sendgrid-nodejs/blob/e29d125629bad8e21ca695c9ad23d429a33c8ae6/packages/helpers/classes/mail.d.ts#L34) class it should be `sandboxMode` not `sandbox`.

I discovered this after sending several dozen emails thinking the sandbox mode was enabled, oops!