### PR TITLE
fix: travis autodeploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ deploy:
     skip_cleanup: true
     on:
       tags: true
-      condition: $version=10
+      condition: $version = 10
 
 notifications:
   slack:


### PR DESCRIPTION
Fixes bug introduced in #1123 where node version was v10 for all builds.

This also undoes some changes introduced in #1112 but looking at the travis builds, the version wasn't being set properly.