### PR TITLE
chore: collapse multiple mail-send TS signatures

### DIFF
--- a/packages/mail/src/mail.d.ts
+++ b/packages/mail/src/mail.d.ts
@@ -26,12 +26,7 @@ declare class MailService {
   /**
    * Send email
    */
-  send(data: MailDataRequired, isMultiple?: boolean, cb?: (err: Error | ResponseError, result: [ClientResponse, {}]) => void): Promise<[ClientResponse, {}]>;
-
-  /**
-   * Send emails
-   */
-  send(data: MailDataRequired[], isMultiple?: boolean, cb?: (err: Error | ResponseError, result: [ClientResponse, {}]) => void): Promise<[ClientResponse, {}]>;
+  send(data: MailDataRequired | MailDataRequired[], isMultiple?: boolean, cb?: (err: Error | ResponseError, result: [ClientResponse, {}]) => void): Promise<[ClientResponse, {}]>;
 
   /**
    * Send multiple emails (shortcut)


### PR DESCRIPTION
From typescript docs overloads should be used if

>  ...will return two different things based on what the user has passed in

Here is not the case, so we can have one signature only where the first argument can be one thing or the other.

With this we can have a wrapper for the send that will retain all the types and allow both types on the first param.

eg:
```javascript
const wrap = <T extends Array<any>, U>(fn: (...args: T) => U) => {
  return (...args: T): U => fn(...args)
}

const send = wrap(sgMail.send)
``` 

Before this PR and because both signatures had the same number of params I was having troubles (if it's possible) to retain both signatures. It was picking the last one.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified
