### PR TITLE
fix: change @starkbank/ecdsa dependency v0.0.3 to updated starkbank-e…

### DIFF
--- a/packages/eventwebhook/package.json
+++ b/packages/eventwebhook/package.json
@@ -20,7 +20,7 @@
     "node": "6.* || 8.* || >=10.*"
   },
   "dependencies": {
-    "@starkbank/ecdsa": "^0.0.3"
+    "starkbank-ecdsa": "^1.1.1"
   },
   "tags": [
     "sendgrid"

--- a/packages/eventwebhook/src/eventwebhook.d.ts
+++ b/packages/eventwebhook/src/eventwebhook.d.ts
@@ -1,4 +1,4 @@
-import {PublicKey} from "@starkbank/ecdsa";
+import {PublicKey} from "starkbank-ecdsa";
 
 declare class EventWebhook {
     /**

--- a/packages/eventwebhook/src/eventwebhook.js
+++ b/packages/eventwebhook/src/eventwebhook.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const ecdsa = require('@starkbank/ecdsa');
+const ecdsa = require('starkbank-ecdsa');
 const Ecdsa = ecdsa.Ecdsa;
 const Signature = ecdsa.Signature;
 const PublicKey = ecdsa.PublicKey;


### PR DESCRIPTION
Resolves #1188

# Fixes #

The starkbank ECDSA dependency was pointed at the deprecated package (@starkbank/ecdsa, v0.0.3). This PR points it to the new repo (starkbank-ecdsa, v1.1.1). The previous interfaces and functionalities were preserved in the new package, so no breaking changes are expected.