### PR TITLE
chore: remove chalk dependency

### DIFF
--- a/packages/helpers/classes/response-error.js
+++ b/packages/helpers/classes/response-error.js
@@ -1,11 +1,6 @@
 'use strict';
 
 /**
- * Dependencies
- */
-const chalk = require('chalk');
-
-/**
  * Response error class
  */
 class ResponseError extends Error {
@@ -19,12 +14,12 @@ class ResponseError extends Error {
     super();
 
     //Extract data from response
-    const {headers, status, statusText, data} = response;
+    const { headers, status, statusText, data } = response;
 
     //Set data
     this.code = status;
     this.message = statusText;
-    this.response = {headers, body: data};
+    this.response = { headers, body: data };
 
     //Capture stack trace
     if (!this.stack) {
@@ -40,13 +35,13 @@ class ResponseError extends Error {
    * Convert to string
    */
   toString() {
-    const {body} = this.response;
-    let err = chalk.red(`${this.message} (${this.code})`);
+    const { body } = this.response;
+    let err = `${this.message} (${this.code})`;
     if (body && Array.isArray(body.errors)) {
       body.errors.forEach(error => {
-        const message = chalk.yellow(error.message);
-        const field = chalk.grey(error.field);
-        const help = chalk.grey(error.help);
+        const message = error.message;
+        const field = error.field;
+        const help = error.help;
         err += `\n  ${message}\n    ${field}\n    ${help}`;
       });
     }
@@ -57,8 +52,8 @@ class ResponseError extends Error {
    * Convert to simple object for JSON responses
    */
   toJSON() {
-    const {message, code, response} = this;
-    return {message, code, response};
+    const { message, code, response } = this;
+    return { message, code, response };
   }
 }
 

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -30,7 +30,6 @@
     "helpers"
   ],
   "dependencies": {
-    "chalk": "^2.0.1",
     "deepmerge": "^4.2.2"
   }
 }


### PR DESCRIPTION
Fixes #1202

# Fixes #

Remove dependency on `chalk` package and its usage in the [`ResponseError` class](https://github.com/sendgrid/sendgrid-nodejs/blob/a0f4876f4a5d9959321820f2ea7682852d3fb912/packages/helpers/classes/response-error.js#L42).

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a GitHub Issue in this repository.
