### PR TITLE
chore: enhance client-related typings

### DIFF
--- a/packages/client/src/client.d.ts
+++ b/packages/client/src/client.d.ts
@@ -46,5 +46,8 @@ declare class Client {
   request(data: ClientRequest, cb?: (err: ResponseError, response: [ClientResponse, any]) => void): Promise<[ClientResponse, any]>;
 }
 
-declare const client: Client & { Client: typeof Client };
+declare const client: Client;
+// @ts-ignore
 export = client
+
+export {Client};

--- a/packages/helpers/classes/request.d.ts
+++ b/packages/helpers/classes/request.d.ts
@@ -1,3 +1,5 @@
+import * as https from 'https';
+
 type HttpMethod = 'get'|'GET'|'post'|'POST'|'put'|'PUT'|'patch'|'PATCH'|'delete'|'DELETE';
 
 export default interface RequestOptions<TData = any, TParams = object> {
@@ -7,4 +9,5 @@ export default interface RequestOptions<TData = any, TParams = object> {
     qs?: TParams;
     body?: TData;
     headers?: object;
+    httpsAgent?: https.Agent;
 }

--- a/packages/mail/src/mail.d.ts
+++ b/packages/mail/src/mail.d.ts
@@ -1,4 +1,4 @@
-import { Client } from "@sendgrid/client";
+import {Client} from "@sendgrid/client";
 import {ClientResponse} from "@sendgrid/client/src/response";
 import {ResponseError} from "@sendgrid/helpers/classes";
 import {MailDataRequired} from "@sendgrid/helpers/classes/mail";

--- a/packages/mail/src/mail.d.ts
+++ b/packages/mail/src/mail.d.ts
@@ -1,3 +1,4 @@
+import { Client } from "@sendgrid/client";
 import {ClientResponse} from "@sendgrid/client/src/response";
 import {ResponseError} from "@sendgrid/helpers/classes";
 import {MailDataRequired} from "@sendgrid/helpers/classes/mail";
@@ -7,6 +8,11 @@ declare class MailService {
    * SendGrid API key passthrough for convenience.
    */
   setApiKey(apiKey: string): void;
+
+  /**
+   * Client to use for invoking underlying API
+   */
+  setClient(client: Client): void;
 
   /**
    * Twilio Email Auth passthrough for convenience.

--- a/test/typescript/client.ts
+++ b/test/typescript/client.ts
@@ -1,4 +1,5 @@
 import Client = require("@sendgrid/client");
+import * as https from 'https';
 
 // Test setApiKey() method
 Client.setApiKey("MY_SENDGRID_API_KEY");
@@ -11,7 +12,8 @@ Client.setDefaultHeader({
 // Test setDefaultRequest() method
 Client.setDefaultRequest({
   url: "/test",
-}).setDefaultRequest("method", "POST");
+}).setDefaultRequest("method", "POST")
+  .setDefaultRequest('httpsAgent', new https.Agent())
 
 // Test createHeaders() method
 Client.createHeaders({

--- a/test/typescript/mail.ts
+++ b/test/typescript/mail.ts
@@ -1,7 +1,11 @@
+import { Client } from "@sendgrid/client";
 import sgMail = require("@sendgrid/mail");
 
 // Test setApiKey() method
 sgMail.setApiKey("MY_SENDGRID_API_KEY");
+
+// Test setClient() method
+sgMail.setClient(new Client());
 
 // Test setSubstitutionWrappers() method
 sgMail.setSubstitutionWrappers("{{", "}}")


### PR DESCRIPTION
# Fixes #

The MailService has a method to set a client, but it isn't exposed in typings. Adding this so there is an easier way to customize underlying agents used (for keep-alive and other connection-pooling settings) without having compilation problems (or subverting the type system by just using 'any')

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [X] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [X] I have read the [Contribution Guidelines](https://github.com/sendgrid/sendgrid-nodejs/blob/main/CONTRIBUTING.md) and my PR follows them
- [X] I have titled the PR appropriately
- [X] I have updated my branch with the main branch
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://support.sendgrid.com), or create a GitHub Issue in this repository.
