### PR TITLE
fix: send email with custom headers at mail-service.js 

### DIFF
--- a/packages/mail/src/classes/mail-service.js
+++ b/packages/mail/src/classes/mail-service.js
@@ -201,6 +201,7 @@ class MailService {
       const request = {
         method: 'POST',
         url: '/v3/mail/send',
+        headers: mail.headers,
         body,
       };
 

--- a/packages/mail/src/mail.spec.js
+++ b/packages/mail/src/mail.spec.js
@@ -52,5 +52,20 @@ describe('sgMail.send()', () => {
       sgMail.send(data, false, {});
     }).to.throw(Error);
   });
+
+  it('should include custom headers to the request', () => {
+    sgClient.setDefaultHeader('X-Mock', 201);
+    const clientSpy = sinon.spy(sgClient, "request")
+    return sgMail
+      .send(Object.assign(data, { headers: { customHeader: "Custom Header Content" } }))
+      .then(([response, body]) => {
+        expect(response.statusCode).to.equal(201);
+        expect(clientSpy).to.have.been.calledWith(sinon.match({
+          url: "/v3/mail/send",
+          method: "POST",
+          headers: { customHeader: "Custom Header Content" }
+        }));
+      });
+  });
 });
 


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  <type>[!]: <description>
Where <type> is one of: docs, chore, feat, fix, test.
Add a '!' after the type for breaking changes (e.g. feat!: new breaking feature).

**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2
-->
There is no way how to add custom headers to the request through the `Mail` package. The `Client` package (as a dependency of `Mail`) already works with custom headers well enough. The test checks if the request includes the added custom header. 


### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/sendgrid/sendgrid-nodejs/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://support.sendgrid.com), or create a GitHub Issue in this repository.
