### PR TITLE
fix: Node 6 build failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.7.7",
     "@babel/core": "^7.7.7",
     "@babel/node": "^7.7.7",
-    "chai": "^4.0.1",
+    "chai": "~4.2.*",
     "chai-as-promised": "^7.1.1",
     "dirty-chai": "^2.0.1",
     "eslint": "^6.8.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.7.7",
     "@babel/core": "^7.7.7",
     "@babel/node": "^7.7.7",
-    "chai": "~4.2.*",
+    "chai": "4.2.x",
     "chai-as-promised": "^7.1.1",
     "dirty-chai": "^2.0.1",
     "eslint": "^6.8.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.7.7",
     "@babel/core": "^7.7.7",
     "@babel/node": "^7.7.7",
-    "chai": "4.2.x",
+    "chai": "~4.2.0",
     "chai-as-promised": "^7.1.1",
     "dirty-chai": "^2.0.1",
     "eslint": "^6.8.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "sinon-chai": "^2.10.0",
     "typescript": "^3.7.4"
   },
+  "peerDependencies": {
+    "chai": "~4.2.0"
+  },
   "scripts": {
     "lint": "if [ `node --version | cut -d'.' -f1 | cut -c 2` -ge \"8\" ]; then eslint . --fix; else echo \"eslint is not available for node < 8.0\"; fi",
     "test:all": "babel-node ./node_modules/istanbul/lib/cli cover ./node_modules/mocha/bin/_mocha \"**/*.spec.js\"",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.7.7",
     "@babel/core": "^7.7.7",
     "@babel/node": "^7.7.7",
-    "chai": "~4.2.0",
+    "chai": "4.2.0",
     "chai-as-promised": "^7.1.1",
     "dirty-chai": "^2.0.1",
     "eslint": "^6.8.0",
@@ -26,7 +26,7 @@
     "typescript": "^3.7.4"
   },
   "peerDependencies": {
-    "chai": "~4.2.0"
+    "chai": "4.2.0"
   },
   "scripts": {
     "lint": "if [ `node --version | cut -d'.' -f1 | cut -c 2` -ge \"8\" ]; then eslint . --fix; else echo \"eslint is not available for node < 8.0\"; fi",

--- a/package.json
+++ b/package.json
@@ -25,9 +25,6 @@
     "sinon-chai": "^2.10.0",
     "typescript": "^3.7.4"
   },
-  "peerDependencies": {
-    "chai": "4.2.0"
-  },
   "scripts": {
     "lint": "if [ `node --version | cut -d'.' -f1 | cut -c 2` -ge \"8\" ]; then eslint . --fix; else echo \"eslint is not available for node < 8.0\"; fi",
     "test:all": "babel-node ./node_modules/istanbul/lib/cli cover ./node_modules/mocha/bin/_mocha \"**/*.spec.js\"",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -31,6 +31,7 @@
     "axios": "^0.21.1"
   },
   "devDependencies": {
+    "chai": "4.2.0",
     "nock": "^10.0.6"
   },
   "tags": [

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -34,6 +34,9 @@
     "chai": "4.2.0",
     "nock": "^10.0.6"
   },
+  "resolutions": {
+    "chai": "4.2.0"
+  },
   "tags": [
     "http",
     "rest",


### PR DESCRIPTION
This change ensures that we don't pull in [Chai v4.3.0](https://www.chaijs.com/releases/) (which no longer supports Node 6) with `npm install` or `yarn install`.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license