### PR TITLE
chore!: Bump Axios to 0.21.4 to fix ReDoS

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@sendgrid/helpers": "^7.4.6",
-    "axios": "^0.21.1"
+    "axios": "^0.21.4"
   },
   "devDependencies": {
     "chai": "4.2.0",


### PR DESCRIPTION
Fixes issue #1294 . Based on the discussion [here](https://github.com/axios/axios/issues/3979). It actually seems that 0.21.4 is what's necessary to address the fix.

**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

# Fixes #
I changed the version of axios that sendgrid client uses from 0.21.1 to 0.21.4.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/sendgrid/sendgrid-nodejs/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified