### PR TITLE
Added support of replyToList in the library, #339:

### DIFF
--- a/packages/helpers/classes/mail.d.ts
+++ b/packages/helpers/classes/mail.d.ts
@@ -155,6 +155,8 @@ export interface MailData {
   dynamicTemplateData?: { [key: string]: any },
 
   hideWarnings?: boolean,
+
+  replyToList?: EmailJSON | EmailJSON[],
 }
 
 export type MailDataRequired = MailData & (
@@ -179,6 +181,7 @@ export interface MailJSON {
   batch_id?: string;
   template_id?: string;
   ip_pool_name?: string;
+  reply_to_list?: EmailJSON[];
 }
 
 export default class Mail {
@@ -353,4 +356,9 @@ export default class Mail {
    * Create a Mail instance from given data
    */
   static create(data: MailData[]): Mail[];
+
+  /**
+   * Set reply_to_list header from given data
+   */
+  setReplyToList(replyToList: EmailJSON[]): void;
 }

--- a/packages/helpers/classes/mail.js
+++ b/packages/helpers/classes/mail.js
@@ -68,7 +68,7 @@ class Mail {
       templateId, personalizations, attachments, ipPoolName, batchId,
       sections, headers, categories, category, customArgs, asm, mailSettings,
       trackingSettings, substitutions, substitutionWrappers, dynamicTemplateData, isMultiple,
-      hideWarnings,
+      hideWarnings, replyToList,
     } = data;
 
     //Set data
@@ -90,6 +90,7 @@ class Mail {
     this.setMailSettings(mailSettings);
     this.setTrackingSettings(trackingSettings);
     this.setHideWarnings(hideWarnings);
+    this.setReplyToList(replyToList);
 
     if (this.isDynamic) {
       this.setDynamicTemplateData(dynamicTemplateData);
@@ -504,7 +505,7 @@ class Mail {
       from, replyTo, sendAt, subject, content, templateId,
       personalizations, attachments, ipPoolName, batchId, asm,
       sections, headers, categories, customArgs, mailSettings,
-      trackingSettings,
+      trackingSettings, replyToList,
     } = this;
 
     //Initialize with mandatory values
@@ -559,6 +560,9 @@ class Mail {
     }
     if (typeof ipPoolName !== 'undefined') {
       json.ipPoolName = ipPoolName;
+    }
+    if(typeof replyToList !== 'undefined') {
+      json.replyToList = replyToList;
     }
 
     //Return as snake cased object
@@ -666,6 +670,19 @@ class Mail {
       propertyName,
       value,
       [this._checkUndefined, this._createCheckThatThrows(Array.isArray, 'Array expected for`' + propertyName + '`')]);
+  }
+
+  /**
+   * Set the replyToList from email body
+   */
+   setReplyToList(replyToList) {
+    if (this._doArrayCheck('replyToList', replyToList) && replyToList.length) {
+      if (!replyToList.every(replyTo => replyTo && typeof replyTo.email === 'string')) {
+        throw new Error('Expected each replyTo to contain a `email` string');
+      }
+      // this.replyToList = EmailAddress.create(replyToList);
+      this.replyToList = replyToList;
+    }
   }
 }
 

--- a/packages/mail/src/mail.spec.js
+++ b/packages/mail/src/mail.spec.js
@@ -17,7 +17,7 @@ before(() => {
  * Default mock header
  */
 beforeEach(() => {
-  sgClient.setDefaultHeader('X-Mock', 200);
+  sgClient.setDefaultHeader('X-Mock', 202);
 });
 
 /**
@@ -38,12 +38,12 @@ describe('sgMail.send()', () => {
     return expect(sgMail.send()).to.eventually.be.rejectedWith(Error);
   });
 
-  it('should send a basic email', () => {
-    sgClient.setDefaultHeader('X-Mock', 201);
+  it('should send a basic email', async () => {
+    sgClient.setDefaultHeader('X-Mock', 202);
     return sgMail
       .send(data)
       .then(([response, body]) => {
-        expect(response.statusCode).to.equal(201);
+        expect(response.statusCode).to.equal(202);
       });
   });
 
@@ -53,19 +53,84 @@ describe('sgMail.send()', () => {
     }).to.throw(Error);
   });
 
-  it('should include custom headers to the request', () => {
-    sgClient.setDefaultHeader('X-Mock', 201);
+  it('should include custom headers to the request', async () => {
+    sgClient.setDefaultHeader('X-Mock', 202);
     const clientSpy = sinon.spy(sgClient, "request")
     return sgMail
       .send(Object.assign(data, { headers: { customHeader: "Custom Header Content" } }))
       .then(([response, body]) => {
-        expect(response.statusCode).to.equal(201);
+        expect(response.statusCode).to.equal(202);
         expect(clientSpy).to.have.been.calledWith(sinon.match({
           url: "/v3/mail/send",
           method: "POST",
           headers: { customHeader: "Custom Header Content" }
         }));
       });
+  });
+
+  it('should send email with correct replyToList format', async () => {
+    sgClient.setDefaultHeader('X-Mock', 202);
+    data["replyToList"] = [
+      {
+        "name": "Test Team",
+        "email": "test@example.org"
+      },
+      {
+        "name": "Support Test Team",
+        "email": "support.test@example.org"
+      }
+    ];
+    return sgMail
+      .send(data)
+      .then(([response, body]) => {
+        expect(response.statusCode).to.equal(202);
+      });
+  });
+
+  it('should throw error with wrong replyToList format', async () => {
+    sgClient.setDefaultHeader('X-Mock', 202);
+    data["replyToList"] = {
+      "name": "Support Test Team",
+      "email": "support.test@example.org"
+    };
+    return expect(function() {
+      sgMail.send(data, false, {});
+    }).to.throw(Error);
+  });
+
+  it('should throw error if any record in replyToList is without email', async () => {
+    data["replyToList"] = [
+      {
+        "name": "Test Team",
+        "email": "test@example.org"
+      },
+      {
+        "name": "Support Test Team"
+      }
+    ];
+    return expect(function() {
+      sgMail.send(data, false, {});
+    }).to.throw(Error);
+  });
+
+  it('should throw error if both replyTo and replyToList are mentioned', async () => {
+    data["replyTo"] = {
+        "name": "Manual Tester",
+        "email": "manual.test@example.org"
+      };
+    data["replyToList"] = [
+      {
+        "name": "Test Team",
+        "email": "test@example.org"
+      },
+      {
+        "name": "Support Test Team",
+        "email": "support.test@example.org"
+      }
+    ];
+    return expect(function() {
+      sgMail.send(data, false, {});
+    }).to.throw(Error);
   });
 });
 


### PR DESCRIPTION
Implementation of #339 & #1301
The replyToList support was added in v3 API but it wasn't supported in the library. With this changes, we can:
- Use the replyToList header to set multiple emails in the replyTo
- The replyToList object, must at least have an `email` parameter and may also contain a name parameter.
- Fixed old test cases that were failing
- In test cases, changed the success response code according to new SendGrid standard ([link](https://docs.sendgrid.com/api-reference/mail-send/mail-send))

Acceptable Format:
`
[
      {
        "name": "Test Team",
        "email": "test@example.org"
      },
      {
        "name": "Support Test Team",
        "email": "support.test@example.org"
      }
]
`
or
`
[
      {
        "email": "test@example.org"
      },
      {
        "name": "Support Test Team",
        "email": "support.test@example.org"
      }
]
`
