### PR TITLE
test: fix issue with new client overriding previously set api key

### DIFF
--- a/test/typescript/mail.ts
+++ b/test/typescript/mail.ts
@@ -1,11 +1,11 @@
 import { Client } from "@sendgrid/client";
 import sgMail = require("@sendgrid/mail");
 
-// Test setApiKey() method
-sgMail.setApiKey("MY_SENDGRID_API_KEY");
-
 // Test setClient() method
 sgMail.setClient(new Client());
+
+// Test setApiKey() method
+sgMail.setApiKey("MY_SENDGRID_API_KEY");
 
 // Test setSubstitutionWrappers() method
 sgMail.setSubstitutionWrappers("{{", "}}")


### PR DESCRIPTION
I was using the tests as informal documentation so I wasn't sure whether to use the `test` or the `doc` tag but since I haven't modified any test output I'm going with `doc` as it applies more closely to how I was interpreting the code.

if you call `sgMail.setClient()` _before_ you call `sgMail.setApiKey()` then everything is great. If you call them in the order that this test does you'll forever get `Unauthorized` 401 section with `data.headers` in `node_modules/@sendgrid/client/src/classes/client.js` `createRequest()` function not including `Bearer Authorization <<YOUR_API_KEY>>`

This issue is reproducible whether you set the client / key at the top outside of a typescript class, inside the typescript class' constructor, or inside the function right before the `sgMail.send` call.


### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/sendgrid/sendgrid-nodejs/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

Here's a GIF of the issue:
![set_client_order_matters](https://user-images.githubusercontent.com/6250751/134959428-66bc70a0-81bd-4b03-bc64-5e47c0ec7e51.gif)

