### PR TITLE
chore: don't test for EOL node versions

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        node: [ 6, 7, 8, 10, lts ]
+        node: [ '12', '14', '16', 'lts' ]
     env:
       version: ${{ matrix.node }}
       DOCKER_LOGIN: ${{ secrets.DOCKER_USERNAME && secrets.DOCKER_AUTH_TOKEN }}
@@ -49,7 +49,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v2
         with:
-          node-version: 10
+          node-version: 16
 
       - name: Create GitHub Release
         uses: sendgrid/dx-automator/actions/release@main


### PR DESCRIPTION
I think we don't need to test EOL node versions. How is this?