### PR TITLE
docs:fix broken image links on npm

### DIFF
--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -123,4 +123,4 @@ If you need help installing or using the library, please check the [Twilio SendG
 
 If you've instead found a bug in the library or would like new features added, go ahead and open issues or pull requests against this repo!
 
-![Twilio SendGrid Logo](../../twilio_sendgrid_logo.png)
+![Twilio SendGrid Logo](https://github.com/sendgrid/sendgrid-nodejs/blob/main/twilio_sendgrid_logo.png?raw=true)

--- a/packages/contact-importer/README.md
+++ b/packages/contact-importer/README.md
@@ -29,4 +29,4 @@ If you need help installing or using the library, please check the [Twilio SendG
 
 If you've instead found a bug in the library or would like new features added, go ahead and open issues or pull requests against this repo!
 
-![Twilio SendGrid Logo](../../twilio_sendgrid_logo.png)
+![Twilio SendGrid Logo](https://github.com/sendgrid/sendgrid-nodejs/blob/main/twilio_sendgrid_logo.png?raw=true)

--- a/packages/helpers/README.md
+++ b/packages/helpers/README.md
@@ -45,4 +45,4 @@ If you need help installing or using the library, please check the [Twilio SendG
 
 If you've instead found a bug in the library or would like new features added, go ahead and open issues or pull requests against this repo!
 
-![Twilio SendGrid Logo](../../twilio_sendgrid_logo.png)
+![Twilio SendGrid Logo](https://github.com/sendgrid/sendgrid-nodejs/blob/main/twilio_sendgrid_logo.png?raw=true)

--- a/packages/inbound-mail-parser/README.md
+++ b/packages/inbound-mail-parser/README.md
@@ -55,4 +55,4 @@ If you need help installing or using the library, please check the [Twilio SendG
 
 If you've instead found a bug in the library or would like new features added, go ahead and open issues or pull requests against this repo!
 
-![Twilio SendGrid Logo](../../twilio_sendgrid_logo.png)
+![Twilio SendGrid Logo](https://github.com/sendgrid/sendgrid-nodejs/blob/main/twilio_sendgrid_logo.png?raw=true)

--- a/packages/mail/README.md
+++ b/packages/mail/README.md
@@ -108,4 +108,4 @@ If you need help installing or using the library, please check the [Twilio SendG
 
 If you've instead found a bug in the library or would like new features added, go ahead and open issues or pull requests against this repo!
 
-![Twilio SendGrid Logo](../../twilio_sendgrid_logo.png)
+![Twilio SendGrid Logo](https://github.com/sendgrid/sendgrid-nodejs/blob/main/twilio_sendgrid_logo.png?raw=true)


### PR DESCRIPTION
# Fixes #

There's a broken link on the npm pages of each package because npm isn't aware of the notion of the monorepo. Hard-coding the URL to the image is the easiest solution to this problem.

<https://www.npmjs.com/package/@sendgrid/client>
<img width="1174" alt="Screenshot 2022-02-28 at 14 31 57" src="https://user-images.githubusercontent.com/1873245/155991761-9de7fde1-75b9-4e2b-b62e-1877414b9896.png">

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/sendgrid/sendgrid-nodejs/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works -> Not applicable
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file -> Not applicable
- [ ] I have added inline documentation to the code I modified -> Not applicable

If you have questions, please file a [support ticket](https://support.sendgrid.com), or create a GitHub Issue in this repository.
