### PR TITLE
fix: Fix typings for eventwebhook.d.ts PublicKey

### DIFF
--- a/packages/eventwebhook/src/eventwebhook.d.ts
+++ b/packages/eventwebhook/src/eventwebhook.d.ts
@@ -1,4 +1,10 @@
-import {PublicKey} from "starkbank-ecdsa";
+// From starkbank-ecdsa, minimal interface of PublicKey
+declare class PublicKey {
+  toString(encode?: boolean): string;
+  static fromPem(pem: string): PublicKey;
+  static fromDer(der: string): PublicKey;
+  static fromString(key: string): PublicKey;
+}
 
 declare class EventWebhook {
     /**


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  <type>[!]: <description>
Where <type> is one of: docs, chore, feat, fix, test.
Add a '!' after the type for breaking changes (e.g. feat!: new breaking feature).

**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2
-->

# Fixes

Installing `@sendgrid/eventwebhook` in a project using typescript cannot properly compile because `starkbank-ecdsa` does not provide any typings and none are available in DefinitelyTyped project either.
Right now the only way to use the module is to ourselves provide a definition of `starkbank-ecdsa` OR patch-package `@sendgrid/eventwebhook`

I've decided to change the import statement with a minimal interface of `PublicKey` which should be enough to use the package properly in a typescript project.

Technically speaking, `@types/node` is also required because you use `Buffer` in the types, but a typescript project without it would be weird so I think we can let that one as-is.


### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/sendgrid/sendgrid-nodejs/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified
