### PR TITLE
docs: Add use case for substitutions

### DIFF
--- a/docs/use-cases/README.md
+++ b/docs/use-cases/README.md
@@ -5,6 +5,7 @@ This documentation provides examples for specific Twilio SendGrid v3 API use cas
 * [Send a Single Email to Multiple Recipients](single-email-multiple-recipients.md)
 * [Send Multiple Emails to Multiple Recipients](multiple-emails-multiple-recipients.md)
 * [Send Multiple Emails with Personalizations](multiple-emails-personalizations.md)
+* [Send Multiple Emails with Personalizations and Substitutions](multiple-emails-personalizations-with-substitutions.md)
 * [CC, BCC and Reply To](cc-bcc-reply-to.md)
 * [Flexible Email Address Fields](flexible-address-fields.md)
 * [Handling Success/Failure/Errors](success-failure-errors.md)

--- a/docs/use-cases/multiple-emails-personalizations-with-substitutions.md
+++ b/docs/use-cases/multiple-emails-personalizations-with-substitutions.md
@@ -1,0 +1,77 @@
+# Send Multiple Emails with Personalizations and Substitutions
+
+Personalizations are an array of objects, each representing a separate email, that allow you to customize the metadata of each email sent within a request. With substitutions you can also have the email template dynamically be updated through [substitution tags](https://docs.sendgrid.com/for-developers/sending-email/substitution-tags). 
+
+The below example shows how multiple emails, each with varying metadata and substitutions, are sent with personalizations.
+
+```js
+const sgMail = require('@sendgrid/mail');
+
+sgMail.setApiKey(process.env.SENDGRID_API_KEY);
+
+const msg = {
+  from: 'sender1@example.org',
+  subject: 'Ahoy!',
+  text: 'Ahoy {{name}}!',
+  html: '<p>Ahoy {{name}}!</p>',
+  personalizations: [
+    {
+      to: 'recipient1@example.org',
+      substitutions: {
+        name: 'Jon'
+      }
+    },
+    {
+      to: 'recipient2@example.org',
+      substitutions: {
+        name: 'Jane'
+      }
+    },
+    {
+      to: 'recipient3@example.org',
+      substitutions: {
+        name: 'Jack'
+      }
+    }
+  ],
+};
+
+sgMail.send(msg);
+```
+
+The default `substitutionWrappers` are `{{` and `}}` in the node.js library, but you can change it using the `substitutionWrappers` property.
+
+You can also use the SendGrid helper classes to achieve the same outcome:
+
+```js
+const sgMail = require('@sendgrid/mail');
+const sgHelpers = require('@sendgrid/helpers');
+const Mail = sgHelpers.classes.Mail;
+const Personalization = sgHelpers.classes.Personalization;
+
+sgMail.setApiKey(process.env.SENDGRID_API_KEY);
+const mail = new Mail();
+mail.setFrom('sender1@example.org');
+mail.setSubject('Ahoy');
+mail.addTextContent('Ahoy {{name}}!');
+mail.addHtmlContent('<p>Ahoy {{name}}!</p>');
+
+const personalization1 = new Personalization();
+personalization1.setTo('recipient1@example.org');
+personalization1.addSubstitution('name', 'Jon');
+mail.addPersonalization(personalization1);
+
+const personalization2 = new Personalization();
+personalization1.setTo('recipient2@example.org');
+personalization1.addSubstitution('name', 'Jane');
+mail.addPersonalization(personalization2);
+
+const personalization3 = new Personalization();
+personalization1.setTo('recipient3@example.org');
+personalization1.addSubstitution('name', 'Jack');
+mail.addPersonalization(personalization3);
+
+sgMail.send(mail);
+```
+
+Refer to [the Sendgrid documentation](https://docs.sendgrid.com/for-developers/sending-email/personalizations) for more details about personalizations.

--- a/docs/use-cases/multiple-emails-personalizations-with-substitutions.md
+++ b/docs/use-cases/multiple-emails-personalizations-with-substitutions.md
@@ -74,4 +74,4 @@ mail.addPersonalization(personalization3);
 sgMail.send(mail);
 ```
 
-Refer to [the Sendgrid documentation](https://docs.sendgrid.com/for-developers/sending-email/personalizations) for more details about personalizations.
+Refer to [the SendGrid documentation](https://docs.sendgrid.com/for-developers/sending-email/personalizations) for more details about personalizations.


### PR DESCRIPTION
**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

This PR adds a use case to the documentation for using substitutions. 
It wasn't easy to find how to do [substitutions to answer this StackOverflow question](https://stackoverflow.com/questions/72200424/azure-app-service-snat-port-exhaustion-on-sendgrid-connection/72312725#72312725), so I decided to contribute a sample for it.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/sendgrid/sendgrid-nodejs/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified