### PR TITLE
fix: Changed contentId to content_id for correct type

### DIFF
--- a/packages/helpers/classes/attachment.d.ts
+++ b/packages/helpers/classes/attachment.d.ts
@@ -3,7 +3,7 @@ export interface AttachmentData {
   filename: string;
   type?: string;
   disposition?: string;
-  contentId?: string;
+  content_id?: string;
 }
 
 export interface AttachmentJSON {
@@ -19,7 +19,7 @@ export default class Attachment implements AttachmentData {
   filename: string;
   type?: string;
   disposition?: string;
-  contentId?: string;
+  content_id?: string;
   
   constructor(data?: AttachmentData);
 


### PR DESCRIPTION


<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  <type>[!]: <description>
Where <type> is one of: docs, chore, feat, fix, test.
Add a '!' after the type for breaking changes (e.g. feat!: new breaking feature).

**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2
-->

# Fixes #

In order for the 'Content-ID' header to be set for the attachment, the parameter 'content_id' has to be set. 'contentId' isn't registered as the header, and the header is not provided in the email. The only workaround is to not use types, which defeats the purpose.

This should fix the type

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x ] I have read the [Contribution Guidelines](https://github.com/sendgrid/sendgrid-nodejs/blob/main/CONTRIBUTING.md) and my PR follows them
- [x ] I have titled the PR appropriately
- [x ] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://support.sendgrid.com).