### PR TITLE
fix: Export type PublicKey to allow type declarations

### DIFF
--- a/packages/eventwebhook/src/eventwebhook.d.ts
+++ b/packages/eventwebhook/src/eventwebhook.d.ts
@@ -37,4 +37,5 @@ declare class EventWebhookHeader {
 export {
     EventWebhook,
     EventWebhookHeader,
+    PublicKey,
 };


### PR DESCRIPTION
Without this, I have to write something awful like:

```
import { EventWebhook } from '@sendgrid/eventwebhook';
let sendgridEcPublicKey: ReturnType<EventWebhook['convertPublicKeyToECDSA']>;
```

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/sendgrid/sendgrid-nodejs/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [ ] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://support.sendgrid.com).