### PR TITLE
Issue: Where are TypeScript definitions for webhook events?

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,4 @@ If you need help using SendGrid, please check the [Twilio SendGrid Support Help 
 <a name="license"></a>
 # License
 [The MIT License (MIT)](LICENSE)
+


### PR DESCRIPTION
[I see webhook payloads casually described here](https://docs.sendgrid.com/for-developers/tracking-events/event), but I would really like to see TypeScript definitions for this integrated into `@sendgrid/eventwebhook`. Do such definitions exist anywhere? Would you accept a pull request that includes them?