### PR TITLE
fix: properly require 1 element in `MailDataRequired` type

### DIFF
--- a/packages/helpers/classes/mail.d.ts
+++ b/packages/helpers/classes/mail.d.ts
@@ -169,7 +169,7 @@ export interface MailData {
 }
 
 export type MailDataRequired = MailData & (
-    { text: string } | { html: string } | { templateId: string } | { content: MailContent[] & { 0: MailContent } });
+    { text: string } | { html: string } | { templateId: string } | { content: [MailContent, ...MailContent[]][] });
 
 export interface MailJSON {
   from: EmailJSON;


### PR DESCRIPTION
Current type does not work with the latest versions of typescript. This updates the type so it remains an array, and not the intersection of an object and an array.

<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  <type>[!]: <description>
Where <type> is one of: docs, chore, feat, fix, test, misc.
Add a '!' after the type for breaking changes (e.g. feat!: new breaking feature).

**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2
-->

# Fixes #

A short description of what this PR does.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [ ] I have read the [Contribution Guidelines](https://github.com/sendgrid/sendgrid-nodejs/blob/main/CONTRIBUTING.md) and my PR follows them
- [ ] I have titled the PR appropriately
- [ ] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://support.sendgrid.com).