### PR TITLE
fix!: Upgrade contact-importer to current contacts API

### DIFF
--- a/packages/contact-importer/src/importer.d.ts
+++ b/packages/contact-importer/src/importer.d.ts
@@ -1,20 +1,22 @@
+import * as sendgrid from "@sendgrid/client";
+
 declare interface ContactImporterOptions {
     batchSize?: number;
     rateLimitLimit?: number;
     rateLimitPeriod?: number;
+    listIds?: number[];
 }
 
 declare interface Contact {
     email: string;
     first_name?: string;
     last_name?: string;
-    age?: number;
 }
 
 declare class ContactImporter {
-    constructor(sg, options?: ContactImporterOptions);
+    constructor(sg: typeof sendgrid, options?: ContactImporterOptions);
 
-    push(data: Contact|Contact[])
+    push(data: Contact|Contact[]): void;
 
     on(event: "success", cb: (result: any, batch: Contact[]) => void): void;
     on(event: "error", cb: (err: Error, batch?: Contact[]) => void): void;

--- a/packages/contact-importer/src/importer.js
+++ b/packages/contact-importer/src/importer.js
@@ -25,6 +25,9 @@ class ContactImporter extends EventEmitter {
     // Length of rate limit period (miliseconds).
     this.rateLimitPeriod = options.rateLimitPeriod || 2000;
 
+    // Identifier of the new contact list to create or to add contacts to.
+    this.listIds = options.listIds || [];
+
     // Create a throttler that will process no more than `rateLimitLimit` requests every `rateLimitPeriod` ms.
     this.throttle = new Bottleneck(0, 0);
     this.throttle.changeReservoir(this.rateLimitLimit);
@@ -78,9 +81,9 @@ class ContactImporter extends EventEmitter {
     debug('sending batch (%s items)', data.length);
 
     const request = {
-      method: 'POST',
-      uri: '/v3/contactdb/recipients',
-      body: data,
+      method: 'PUT',
+      uri: '/v3/marketing/contacts',
+      body: { contacts: data, list_ids: this.listIds },
     };
 
     context.sg.request(request)


### PR DESCRIPTION
The `@sendgrid/contact-importer` package uses the legacy marketing campaigns API (`POST /v3/contactdb/recipients`). This API has [been discontinued and only returns the 403 code.](https://stackoverflow.com/a/57020757/1567835)

This is a breaking change because this is a move to a new API for a new product version and the new API does not support a stock `age` field anymore.