### PR TITLE
fix: typings for Client.setDefaultRequest

### DIFF
--- a/packages/client/src/client.d.ts
+++ b/packages/client/src/client.d.ts
@@ -28,7 +28,7 @@ declare class Client {
   /**
    * Set default request
    */
-  setDefaultRequest<K extends keyof ClientRequest>(key: K | ClientRequest, value ?: ClientRequest[K]): this;
+  setDefaultRequest<K extends keyof ClientRequest>(key: K | Partial<ClientRequest>, value ?: ClientRequest[K]): this;
 
   /**
    * Create headers for request

--- a/test/typescript/client.ts
+++ b/test/typescript/client.ts
@@ -10,9 +10,14 @@ Client.setDefaultHeader({
 }).setDefaultHeader("X-Testing", "yes");
 
 // Test setDefaultRequest() method
-Client.setDefaultRequest({
-  url: "/test",
-}).setDefaultRequest("method", "POST")
+Client
+  .setDefaultRequest({
+    url: "/test",
+  })
+  .setDefaultRequest({
+    httpsAgent: new https.Agent(),
+  })
+  .setDefaultRequest("method", "POST")
   .setDefaultRequest('httpsAgent', new https.Agent())
 
 // Test createHeaders() method


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  <type>[!]: <description>
Where <type> is one of: docs, chore, feat, fix, test, misc.
Add a '!' after the type for breaking changes (e.g. feat!: new breaking feature).

**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2
-->

# Fixes

The `ClientRequest` type (alias of `RequestOptions`) in `Client.setDefaultRequest` has **required** field `url`. 

This means, when using `Client.setDefaultRequest({ httpsAgent: new https.Agent() })`, for example, TypeScript will error with field `url` is missing.

This PR makes the type partial, so all fields are optional which reflects the actual behaviour.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/sendgrid/sendgrid-nodejs/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] ~I have added the necessary documentation about the functionality in the appropriate .md file~
- [x] ~I have added inline documentation to the code I modified~

