### PR TITLE
fix: Fix setApiKey and setTwilioEmailAuth to prevent overwriting baseUrl

### DIFF
--- a/packages/client/src/classes/client.js
+++ b/packages/client/src/classes/client.js
@@ -38,7 +38,6 @@ class Client {
 
   setApiKey(apiKey) {
     this.auth = 'Bearer ' + apiKey;
-    this.setDefaultRequest('baseUrl', SENDGRID_BASE_URL);
 
     if (!this.isValidApiKey(apiKey)) {
       console.warn(`API key does not start with "${API_KEY_PREFIX}".`);
@@ -48,7 +47,9 @@ class Client {
   setTwilioEmailAuth(username, password) {
     const b64Auth = Buffer.from(username + ':' + password).toString('base64');
     this.auth = 'Basic ' + b64Auth;
-    this.setDefaultRequest('baseUrl', TWILIO_BASE_URL);
+    if (this.defaultRequest.baseUrl === SENDGRID_BASE_URL) {
+      this.setDefaultRequest('baseUrl', TWILIO_BASE_URL);
+    }
 
     if (!this.isValidTwilioAuth(username, password)) {
       console.warn('Twilio Email credentials must be non-empty strings.');

--- a/packages/client/src/client.spec.js
+++ b/packages/client/src/client.spec.js
@@ -106,6 +106,23 @@ describe('setImpersonateSubuser', () => {
   });
 });
 
+describe('setDefaultRequest', () => {
+  const customBaseUrl = 'localhost:3030';
+  const sgClient = require('./client');
+
+  it('should set the custom base URL without being overwritten by setApiKey', () => {
+    sgClient.setDefaultRequest('baseUrl', customBaseUrl);
+    sgClient.setApiKey('SG\.1234567890');
+    expect(sgClient.defaultRequest.baseUrl).to.equal(customBaseUrl);
+  });
+
+  it('should set the custom base URL without being overwritten by setTwilioEmailAuth', () => {
+    sgClient.setDefaultRequest('baseUrl', customBaseUrl);
+    sgClient.setTwilioEmailAuth('username', 'password');
+    expect(sgClient.defaultRequest.baseUrl).to.equal(customBaseUrl);
+  });
+});
+
 describe('test_access_settings_activity_get', () => {
   const request = {};
   request.qs = {


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  <type>[!]: <description>
Where <type> is one of: docs, chore, feat, fix, test, misc.
Add a '!' after the type for breaking changes (e.g. feat!: new breaking feature).

**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2
-->

# Fixes #
If you use `setDefaultRequest` to change `baseUrl` to a custom value, and execute `setDefaultRequest` before `setApiKey`, the `baseUrl` that you thought you had changed to a custom value will be overwritten with `SENDGRID_BASE_URL`.

For example, if you want to send a request to a mock SendGrid prepared in a local environment, you need to be careful about the execution order of `setApiKey` and `setDefaultRequest` as follows.
```javascript
// You must execute setApiKey first.
const client = new Client();
client.setApiKey('SG.xxxxx');
client.setDefaultRequest('baseUrl', 'localhost:3030');
```

In order to resolve it, I've decided to make the following changes, including `setTwilioEmailAuth`, which has a similar dependency:
- Do not execute `setDefaultRequest('baseUrl', SENDGRID_BASE_URL)` inside `setApiKey` since the default value for `baseUrl` is `SENDGRID_BASE_URL` .
- Execute `setDefaultRequest('baseUrl', TWILIO_BASE_URL)` inside `setTwilioEmailAuth` depending on whether `baseUrl` has been updated to a custom value.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/sendgrid/sendgrid-nodejs/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://support.sendgrid.com).