### PR TITLE
docs: qsStringifyOptions example in USAGE.md doesn't work. Use the qs packa…

### DIFF
--- a/packages/client/USAGE.md
+++ b/packages/client/USAGE.md
@@ -1208,7 +1208,8 @@ client
 
 ```javascript
 const client = require('@sendgrid/client')
-client.setDefaultRequest('qsStringifyOptions', {arrayFormat: 'repeat'});
+const qs = require('qs')
+client.setDefaultRequest('paramsSerializer', (params) => qs.stringify(params, {arrayFormat: 'repeat'}));
 
 const request = {}
 const queryParams = {


### PR DESCRIPTION
# Fixes #

Fix the `qsStringifyOptions` option example in USAGE.md. Use the `qs` package together with the `paramsSerializer` option instead.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/sendgrid/sendgrid-nodejs/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://support.sendgrid.com).