### PR TITLE
[DOCSPLAT-1058] Allow params serializer - for arrays

### DIFF
--- a/packages/client/src/classes/client.js
+++ b/packages/client/src/classes/client.js
@@ -139,6 +139,7 @@ class Client {
       data: data.body,
       params: data.qs,
       headers: data.headers,
+      paramsSerializer: { indexes: null },
     };
 
     // Merge data with default request.

--- a/packages/client/src/client.spec.js
+++ b/packages/client/src/client.spec.js
@@ -3081,6 +3081,16 @@ describe('test_whitelabel_links__id__validate_post', () => {
   });
 });
 
+describe.only('test_marketing_integrations__array_query_params__delete', () => {
+  const request = {};
+  request.method = 'DELETE';
+  request.url = '/v3/marketing/integrations';
+  request.qs = { ids: ['id1', 'id2'] };
+  it('should have the correct response code', () => {
+    return testRequest(request, 204);
+  });
+});
+
 describe('test_whitelabel_links__link_id__subuser_post', () => {
   const request = {};
   request.body = {


### PR DESCRIPTION
# Fixes #

- Allows seralization for query params. Info taken for this [forum](https://stackoverflow.com/questions/49944387/how-to-correctly-use-axios-params-with-arrays)

After:

`/v3/marketing/integrations?ids=id1&ids=id2`

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [ ] I have read the [Contribution Guidelines](https://github.com/sendgrid/sendgrid-nodejs/blob/main/CONTRIBUTING.md) and my PR follows them
- [ ] I have titled the PR appropriately
- [ ] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://support.sendgrid.com).