### PR TITLE
fix: import axios correctly

### DIFF
--- a/packages/client/src/classes/client.js
+++ b/packages/client/src/classes/client.js
@@ -1,5 +1,5 @@
 'use strict';
-const axios = require('axios');
+const axios = require('axios').default;
 const pkg = require('../../package.json');
 const {
   helpers: {


### PR DESCRIPTION
# Fixes #

As mentioned in [axios's example](https://axios-http.com/docs/example), in order to use axios with types (which a lot of people are now doing), the `.default` import needs to be used.

This doesn't impact non-typescript based users, but means typescript users can actually use sendgrid again.

Closes #1426

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/sendgrid/sendgrid-nodejs/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
~- [ ] I have added tests that prove my fix is effective or that my feature works~
~- [ ] I have added the necessary documentation about the functionality in the appropriate .md file~
~- [ ] I have added inline documentation to the code I modified~

If you have questions, please file a [support ticket](https://support.sendgrid.com).