### PR TITLE
Update @sendgrid/client dependency to version 8.1.6

### DIFF
--- a/packages/mail/package.json
+++ b/packages/mail/package.json
@@ -27,7 +27,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@sendgrid/client": "^8.1.5",
+    "@sendgrid/client": "^8.1.6",
     "@sendgrid/helpers": "^8.0.0"
   },
   "tags": [


### PR DESCRIPTION
Version 8.1.6 of @sendgrid/client has a fix for an Axios vulnerability, but @sendgrid/mail still uses 8.1.5. This bumps the version to fix the vulnerability.