### PR TITLE
fix: make types compile under TypeScript 7.0

### DIFF
--- a/packages/client/src/client.d.ts
+++ b/packages/client/src/client.d.ts
@@ -6,6 +6,13 @@ declare class Client {
   constructor();
 
   /**
+   * Class itself, attached at runtime via `module.exports.Client = Client`.
+   * Lets `import client = require("@sendgrid/client")` consumers reach the
+   * class via `client.Client`.
+   */
+  Client: typeof Client;
+
+  /**
    * Set the SendGrid API key.
    */
   setApiKey(apiKey: string): void;
@@ -52,7 +59,4 @@ declare class Client {
 }
 
 declare const client: Client;
-// @ts-ignore
-export = client
-
-export {Client};
+export = client;

--- a/packages/client/src/client.d.ts
+++ b/packages/client/src/client.d.ts
@@ -6,13 +6,6 @@ declare class Client {
   constructor();
 
   /**
-   * Class itself, attached at runtime via `module.exports.Client = Client`.
-   * Lets `import client = require("@sendgrid/client")` consumers reach the
-   * class via `client.Client`.
-   */
-  Client: typeof Client;
-
-  /**
    * Set the SendGrid API key.
    */
   setApiKey(apiKey: string): void;
@@ -58,5 +51,23 @@ declare class Client {
   request(data: ClientRequest, cb?: (err: ResponseError, response: [ClientResponse, any]) => void): Promise<[ClientResponse, any]>;
 }
 
-declare const client: Client;
+/**
+ * The module exports the singleton, with the class attached as
+ * `module.exports.Client` (see index.js), so both meanings of `Client` —
+ * the value and the instance type — stay importable by name.
+ */
+declare namespace client {
+  export {Client};
+
+  export function setApiKey(apiKey: string): void;
+  export function setTwilioEmailAuth(username: string, password: string): void;
+  export function setImpersonateSubuser(subuser: string): void;
+  export function setDefaultHeader(key: string | { [s: string]: string }, value ?: string): Client;
+  export function setDefaultRequest<K extends keyof ClientRequest>(key: K | ClientRequest, value ?: ClientRequest[K]): Client;
+  export function setDataResidency(region: string): Client;
+  export function createHeaders(data: { [key: string]: string }): { [key: string]: string };
+  export function createRequest(data: ClientRequest): ClientRequest;
+  export function request(data: ClientRequest, cb?: (err: ResponseError, response: [ClientResponse, any]) => void): Promise<[ClientResponse, any]>;
+}
+
 export = client;

--- a/packages/mail/src/mail.d.ts
+++ b/packages/mail/src/mail.d.ts
@@ -1,16 +1,9 @@
-import sgClient = require("@sendgrid/client");
+import {Client} from "@sendgrid/client";
 import {ClientResponse} from "@sendgrid/client/src/response";
 import {ResponseError} from "@sendgrid/helpers/classes";
 import {MailDataRequired} from "@sendgrid/helpers/classes/mail";
 
-type Client = InstanceType<typeof sgClient.Client>;
-
 declare class MailService {
-  /**
-   * Class itself, attached at runtime via `module.exports.MailService = MailService`.
-   */
-  MailService: typeof MailService;
-
   /**
    * SendGrid API key passthrough for convenience.
    */
@@ -47,5 +40,23 @@ declare class MailService {
   sendMultiple(data: MailDataRequired, cb?: (error: Error | ResponseError, result: [ClientResponse, {}]) => void): Promise<[ClientResponse, {}]>;
 }
 
-declare const mail: MailService;
+/**
+ * The module exports the singleton, with the class attached as
+ * `module.exports.MailService` (see index.js).
+ */
+declare namespace mail {
+  export {MailService};
+  export {MailDataRequired};
+  export {ClientResponse};
+  export {ResponseError};
+
+  export function setApiKey(apiKey: string): void;
+  export function setClient(client: Client): void;
+  export function setTwilioEmailAuth(username: string, password: string): void;
+  export function setTimeout(timeout: number): void;
+  export function setSubstitutionWrappers(left: string, right: string): void;
+  export function send(data: MailDataRequired | MailDataRequired[], isMultiple?: boolean, cb?: (err: Error | ResponseError, result: [ClientResponse, {}]) => void): Promise<[ClientResponse, {}]>;
+  export function sendMultiple(data: MailDataRequired, cb?: (error: Error | ResponseError, result: [ClientResponse, {}]) => void): Promise<[ClientResponse, {}]>;
+}
+
 export = mail;

--- a/packages/mail/src/mail.d.ts
+++ b/packages/mail/src/mail.d.ts
@@ -1,9 +1,16 @@
-import {Client} from "@sendgrid/client";
+import sgClient = require("@sendgrid/client");
 import {ClientResponse} from "@sendgrid/client/src/response";
 import {ResponseError} from "@sendgrid/helpers/classes";
 import {MailDataRequired} from "@sendgrid/helpers/classes/mail";
 
+type Client = InstanceType<typeof sgClient.Client>;
+
 declare class MailService {
+  /**
+   * Class itself, attached at runtime via `module.exports.MailService = MailService`.
+   */
+  MailService: typeof MailService;
+
   /**
    * SendGrid API key passthrough for convenience.
    */
@@ -41,10 +48,4 @@ declare class MailService {
 }
 
 declare const mail: MailService;
-// @ts-ignore
 export = mail;
-
-export {MailService};
-export {MailDataRequired};
-export {ClientResponse};
-export {ResponseError};

--- a/test/typescript/client.ts
+++ b/test/typescript/client.ts
@@ -31,3 +31,7 @@ Client.request({
 }).then(res => {
   res[0].statusCode;
 });
+
+// Test Client class attached to the module
+const instance: Client.Client = new Client.Client();
+instance.setApiKey("MY_SENDGRID_API_KEY");

--- a/test/typescript/mail.ts
+++ b/test/typescript/mail.ts
@@ -1,8 +1,18 @@
 import { Client } from "@sendgrid/client";
+import { MailDataRequired, ClientResponse, ResponseError } from "@sendgrid/mail";
 import sgMail = require("@sendgrid/mail");
 
 // Test setClient() method
 sgMail.setClient(new Client());
+
+// Test Client used as a type
+const client: Client = new Client();
+sgMail.setClient(client);
+
+// Test types re-exported from the package root
+declare const data: MailDataRequired;
+declare const onSent: (err: Error | ResponseError, result: [ClientResponse, {}]) => void;
+sgMail.send(data, false, onSent);
 
 // Test setApiKey() method
 sgMail.setApiKey("MY_SENDGRID_API_KEY");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,9 +3,9 @@
         "noEmit": true,
         "module": "commonjs",
         "target": "es6",
-        "baseUrl": ".",
+        "types": ["node"],
         "paths": {
-            "@sendgrid/*": ["packages/*"]
+            "@sendgrid/*": ["./packages/*"]
         }
     },
     "include": [


### PR DESCRIPTION
# Fixes #1454

`@sendgrid/client` and `@sendgrid/mail` mix `export = instance` with `export {Class}` and silence the diagnostic with `// @ts-ignore`. TypeScript 7.0 (the Go-port `tsgo` beta) tightens the rule and surfaces it in every consumer:

```
error TS2616: 'Client' can only be imported by using
'import Client = require("@sendgrid/client")' or a default import.
```

The two exports were never reconcilable as written, because `module.exports` is a *singleton instance with a class attached to it* (`index.js` does `module.exports = client; module.exports.Client = Client`), and a `declare const` cannot carry named exports.

So model that shape directly: declare an ambient namespace that merges with the `export =` target. The namespace holds the singleton's methods plus `export {Client}`, which keeps **both meanings** of the name — the class as a value *and* as an instance type — importable by name, with no `@ts-ignore`.

Same shape applied to `MailService` in `packages/mail/src/mail.d.ts`, where the namespace also carries the `MailDataRequired`, `ClientResponse` and `ResponseError` re-exports.

`tsconfig.json` is also bumped to TS 7.0 minimums so `test/typescript/*.ts` keeps type-checking under `tsgo`: `baseUrl` removed, leading `./` added to path mappings, `types: ["node"]` declared explicitly. Without this `tsgo` bails on the config before it type-checks anything.

No runtime change.

## Verification

Both compilers pass:

```
$ tsc --noEmit -p tsconfig.json    # tsc 5.9.3 → exit 0
$ tsgo --noEmit -p tsconfig.json   # @typescript/native-preview 7.0.0-dev → exit 0
```

I also checked the consumer-visible surface end to end — a separate project with `@sendgrid/mail@8.1.6` and `@sendgrid/client@8.1.6` installed from npm and only the `.d.ts` files swapped, so resolution goes through the published `index.d.ts` rather than this repo's `paths` mapping:

| consumer pattern | `main` | this PR |
|---|---|---|
| `import sg = require("@sendgrid/client")`, `new sg.Client()` | ❌ | ✅ |
| `import { Client }` → `new Client()` | ✅ | ✅ |
| `import { Client }` → `c: Client` (type position) | ✅ | ✅ |
| `import { MailDataRequired, ClientResponse, ResponseError }` | ✅ | ✅ |
| `import * as sg from "@sendgrid/mail"` | ✅ | ✅ |
| `import sg from "@sendgrid/mail"` (`esModuleInterop`) | ✅ | ✅ |

Nothing that compiles against `main` stops compiling, and `sg.Client` — which the runtime has always provided but the types denied — now works.

The same matrix passes under `tsgo` with `module: nodenext` (CommonJS consumer). Against `main`, `tsgo` rejects every row with `TS2595`, because `mail.d.ts` itself imports `Client` by name.

I also tried the one-line alternative suggested in review, `export default client;` in place of `export = client`. It fails the repo's own `test/typescript` fixtures under both compilers (27× `TS2339: Property 'setApiKey' does not exist on type 'typeof import(...)'`), because `import sg = require(...)` and `import * as sg` then resolve to the module namespace, whose methods live on a `.default` that does not exist at runtime. It also lets `import sg from "@sendgrid/mail"` compile without `esModuleInterop`, which crashes at runtime with `Cannot read properties of undefined (reading 'setApiKey')`. The only pattern it satisfies is a default import in a CommonJS project with `esModuleInterop` on.

### Known limitation: ESM namespace and named imports

In a native ESM consumer (`"type": "module"`, `module: nodenext`), `import * as sg from "@sendgrid/mail"; sg.setApiKey()` and `import { setApiKey } from "@sendgrid/mail"` now type-check but fail at runtime. Node only exposes `module.exports.MailService` as a named export; the instance methods live on the prototype and are invisible to its CommonJS export detection. `main` rejected these at compile time because the singleton carried no namespace at all. This is the same gap every `export =` package with a namespace merge has, and TypeScript offers no way to model it (a `const` cannot merge with a namespace). ESM consumers should use the default import, `import sg from "@sendgrid/mail"`, which compiles and runs under both `tsc` and `tsgo`. `import { MailService }` and `import { Client }` are fine in ESM, since those are real `module.exports` properties.

### Fixtures

Three cases the existing fixtures did not reach are now covered, each of which fails against `main`:

- `new Client.Client()` off the module (`test/typescript/client.ts`) — `TS2339` on `main`
- `Client` in type position (`test/typescript/mail.ts`) — the only usage the old `export {Client}` protected
- the types re-exported from the package root (`test/typescript/mail.ts`)

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/sendgrid/sendgrid-nodejs/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified

