### PR TITLE
chore: add bugs metadata for mail package

### DIFF
--- a/packages/mail/package.json
+++ b/packages/mail/package.json
@@ -19,6 +19,9 @@
     "type": "git",
     "url": "git://github.com/sendgrid/sendgrid-nodejs.git"
   },
+  "bugs": {
+    "url": "https://github.com/sendgrid/sendgrid-nodejs/issues"
+  },
   "main": "index.js",
   "engines": {
     "node": ">=12.*"


### PR DESCRIPTION
Adds the standard npm `bugs.url` metadata to the published `@sendgrid/mail` package, pointing to the sendgrid-nodejs GitHub issue tracker.

Microbounty reference: https://github.com/charles-openclaw/charles-microbounties/issues/664

Validation:
- node -e "const p=require('./packages/mail/package.json'); if (p.bugs?.url !== 'https://github.com/sendgrid/sendgrid-nodejs/issues') process.exit(1)"
- npm pack --dry-run --ignore-scripts ./packages/mail
- git diff --check