### PR TITLE
fix(mail): add bugs.url to @sendgrid/mail package manifest

### DIFF
--- a/packages/mail/package.json
+++ b/packages/mail/package.json
@@ -15,6 +15,9 @@
   ],
   "license": "MIT",
   "homepage": "https://sendgrid.com",
+  "bugs": {
+    "url": "https://github.com/sendgrid/sendgrid-nodejs/issues"
+  },
   "repository": {
     "type": "git",
     "url": "git://github.com/sendgrid/sendgrid-nodejs.git"


### PR DESCRIPTION
Adds missing `bugs.url` field to `@sendgrid/mail` package.json, pointing to the repository issues page.