### PR TITLE
fix(client): add bugs.url to @sendgrid/client package manifest

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -15,6 +15,9 @@
   ],
   "license": "MIT",
   "homepage": "https://sendgrid.com",
+  "bugs": {
+    "url": "https://github.com/sendgrid/sendgrid-nodejs/issues"
+  },
   "repository": {
     "type": "git",
     "url": "git://github.com/sendgrid/sendgrid-nodejs.git"

--- a/packages/mail/package.json
+++ b/packages/mail/package.json
@@ -15,6 +15,9 @@
   ],
   "license": "MIT",
   "homepage": "https://sendgrid.com",
+  "bugs": {
+    "url": "https://github.com/sendgrid/sendgrid-nodejs/issues"
+  },
   "repository": {
     "type": "git",
     "url": "git://github.com/sendgrid/sendgrid-nodejs.git"


### PR DESCRIPTION
Adds missing `bugs.url` field to `@sendgrid/client` package.json.