### PR TITLE
Add client bugs metadata

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -14,6 +14,9 @@
     "Adam Reis <adam@reis.nz>"
   ],
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/sendgrid/sendgrid-nodejs/issues"
+  },
   "homepage": "https://sendgrid.com",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Adds `bugs.url` metadata to the `@sendgrid/client` package manifest, matching the issue tracker already declared in the repository root package metadata.

This leaves runtime code, dependencies, generated files, package exports, and version fields unchanged.

## Validation

- `node -e "const p=require('./packages/client/package.json'); if (p.bugs?.url !== 'https://github.com/sendgrid/sendgrid-nodejs/issues') throw new Error('bugs.url missing or incorrect'); console.log(JSON.stringify({name:p.name,version:p.version,bugs:p.bugs}))"`
- `(cd packages/client && npm pack --dry-run --ignore-scripts --json)`
- `git diff --check`