### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/packages/mail/package.json
+++ b/packages/mail/package.json
@@ -2,6 +2,9 @@
   "name": "@sendgrid/mail",
   "description": "Twilio SendGrid NodeJS mail service",
   "version": "8.1.6",
+  "bugs": {
+    "url": "https://github.com/sendgrid/sendgrid-nodejs/issues"
+  },
   "author": "Twilio SendGrid <help@twilio.com> (sendgrid.com)",
   "contributors": [
     "Kyle Partridge <kyle.partridge@sendgrid.com>",


### PR DESCRIPTION
Adds missing `bugs` metadata to `packages/mail/package.json`.

Fixes npm tooling unable to resolve package metadata.